### PR TITLE
Correct the save frame name and remove quotes from examples

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -9011,7 +9011,7 @@ _units.code                             degrees
 
 save_
 
-save_save_geom_angle.site_ssg_symmetry_1
+save_geom_angle.site_ssg_symmetry_1
 
     _definition.id               '_geom_angle.site_ssg_symmetry_1'
     _definition.update           2014-06-27
@@ -9047,9 +9047,9 @@ save_save_geom_angle.site_ssg_symmetry_1
     loop_
       _description_example.case
       _description_example.detail
-      "."                  'no symmetry or translation to site'          
-      "4"                  '4th symmetry operation applied'    
-      "7_645"              '7th symmetry position; +a on x, -b on y' 
+      .                  'no symmetry or translation to site'
+      4                  '4th symmetry operation applied'
+      7_645              '7th symmetry position; +a on x, -b on y'
 
 save_
 


### PR DESCRIPTION
The quotes from the '.' values needed to be removed since it changes the overall interpretation of the value (dot symbol vs. inapplicable CIF value).