### PR TITLE
Add the category id for `_cell_subsystem.matrix_W_*` data items

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -7942,6 +7942,7 @@ save_cell_subsystem.matrix_W_1_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_1
      save_
  
@@ -7951,6 +7952,7 @@ save_cell_subsystem.matrix_W_1_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_2
      save_
  
@@ -7960,6 +7962,7 @@ save_cell_subsystem.matrix_W_1_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_3
      save_
  
@@ -7969,6 +7972,7 @@ save_cell_subsystem.matrix_W_1_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_4
      save_
  
@@ -7978,6 +7982,7 @@ save_cell_subsystem.matrix_W_1_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_5
      save_
  
@@ -7987,6 +7992,7 @@ save_cell_subsystem.matrix_W_1_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_6
      save_
  
@@ -7996,6 +8002,7 @@ save_cell_subsystem.matrix_W_1_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_7
      save_
  
@@ -8005,6 +8012,7 @@ save_cell_subsystem.matrix_W_1_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_8
      save_
  
@@ -8014,6 +8022,7 @@ save_cell_subsystem.matrix_W_1_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_9
      save_
  
@@ -8023,6 +8032,7 @@ save_cell_subsystem.matrix_W_1_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_10
      save_
  
@@ -8032,6 +8042,7 @@ save_cell_subsystem.matrix_W_1_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_1_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_1_11
      save_
 
@@ -8041,6 +8052,7 @@ save_cell_subsystem.matrix_W_2_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_1
      save_
  
@@ -8050,6 +8062,7 @@ save_cell_subsystem.matrix_W_2_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_2
      save_
  
@@ -8059,6 +8072,7 @@ save_cell_subsystem.matrix_W_2_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_3
      save_
  
@@ -8068,6 +8082,7 @@ save_cell_subsystem.matrix_W_2_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_4
      save_
  
@@ -8077,6 +8092,7 @@ save_cell_subsystem.matrix_W_2_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_5
      save_
  
@@ -8086,6 +8102,7 @@ save_cell_subsystem.matrix_W_2_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_6
      save_
  
@@ -8095,6 +8112,7 @@ save_cell_subsystem.matrix_W_2_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_7
      save_
  
@@ -8104,6 +8122,7 @@ save_cell_subsystem.matrix_W_2_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_8
      save_
  
@@ -8113,6 +8132,7 @@ save_cell_subsystem.matrix_W_2_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_9
      save_
  
@@ -8122,6 +8142,7 @@ save_cell_subsystem.matrix_W_2_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_10
      save_
  
@@ -8131,6 +8152,7 @@ save_cell_subsystem.matrix_W_2_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_2_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_2_11
      save_
 
@@ -8140,6 +8162,7 @@ save_cell_subsystem.matrix_W_3_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_1
      save_
  
@@ -8149,6 +8172,7 @@ save_cell_subsystem.matrix_W_3_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_2
      save_
  
@@ -8158,6 +8182,7 @@ save_cell_subsystem.matrix_W_3_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_3
      save_
  
@@ -8167,6 +8192,7 @@ save_cell_subsystem.matrix_W_3_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_4
      save_
  
@@ -8176,6 +8202,7 @@ save_cell_subsystem.matrix_W_3_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_5
      save_
  
@@ -8185,6 +8212,7 @@ save_cell_subsystem.matrix_W_3_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_6
      save_
  
@@ -8194,6 +8222,7 @@ save_cell_subsystem.matrix_W_3_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_7
      save_
  
@@ -8203,6 +8232,7 @@ save_cell_subsystem.matrix_W_3_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_8
      save_
  
@@ -8212,6 +8242,7 @@ save_cell_subsystem.matrix_W_3_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_9
      save_
  
@@ -8221,6 +8252,7 @@ save_cell_subsystem.matrix_W_3_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_10
      save_
  
@@ -8230,6 +8262,7 @@ save_cell_subsystem.matrix_W_3_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_3_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_3_11
      save_
 
@@ -8239,6 +8272,7 @@ save_cell_subsystem.matrix_W_4_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_1
      save_
  
@@ -8248,6 +8282,7 @@ save_cell_subsystem.matrix_W_4_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_2
      save_
  
@@ -8257,6 +8292,7 @@ save_cell_subsystem.matrix_W_4_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_3
      save_
  
@@ -8266,6 +8302,7 @@ save_cell_subsystem.matrix_W_4_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_4
      save_
  
@@ -8275,6 +8312,7 @@ save_cell_subsystem.matrix_W_4_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_5
      save_
  
@@ -8284,6 +8322,7 @@ save_cell_subsystem.matrix_W_4_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_6
      save_
  
@@ -8293,6 +8332,7 @@ save_cell_subsystem.matrix_W_4_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_7
      save_
  
@@ -8302,6 +8342,7 @@ save_cell_subsystem.matrix_W_4_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_8
      save_
  
@@ -8311,6 +8352,7 @@ save_cell_subsystem.matrix_W_4_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_9
      save_
  
@@ -8320,6 +8362,7 @@ save_cell_subsystem.matrix_W_4_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_10
      save_
  
@@ -8329,6 +8372,7 @@ save_cell_subsystem.matrix_W_4_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_4_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_4_11
      save_
 
@@ -8338,6 +8382,7 @@ save_cell_subsystem.matrix_W_5_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_1
      save_
  
@@ -8347,6 +8392,7 @@ save_cell_subsystem.matrix_W_5_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_2
      save_
  
@@ -8356,6 +8402,7 @@ save_cell_subsystem.matrix_W_5_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_3
      save_
  
@@ -8365,6 +8412,7 @@ save_cell_subsystem.matrix_W_5_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_4
      save_
  
@@ -8374,6 +8422,7 @@ save_cell_subsystem.matrix_W_5_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_5
      save_
  
@@ -8383,6 +8432,7 @@ save_cell_subsystem.matrix_W_5_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_6
      save_
  
@@ -8392,6 +8442,7 @@ save_cell_subsystem.matrix_W_5_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_7
      save_
  
@@ -8401,6 +8452,7 @@ save_cell_subsystem.matrix_W_5_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_8
      save_
  
@@ -8410,6 +8462,7 @@ save_cell_subsystem.matrix_W_5_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_9
      save_
  
@@ -8419,6 +8472,7 @@ save_cell_subsystem.matrix_W_5_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_10
      save_
  
@@ -8428,6 +8482,7 @@ save_cell_subsystem.matrix_W_5_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_5_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_5_11
      save_
 
@@ -8437,6 +8492,7 @@ save_cell_subsystem.matrix_W_6_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_1
      save_
  
@@ -8446,6 +8502,7 @@ save_cell_subsystem.matrix_W_6_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_2
      save_
  
@@ -8455,6 +8512,7 @@ save_cell_subsystem.matrix_W_6_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_3
      save_
  
@@ -8464,6 +8522,7 @@ save_cell_subsystem.matrix_W_6_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_4
      save_
  
@@ -8473,6 +8532,7 @@ save_cell_subsystem.matrix_W_6_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_5
      save_
  
@@ -8482,6 +8542,7 @@ save_cell_subsystem.matrix_W_6_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_6
      save_
  
@@ -8491,6 +8552,7 @@ save_cell_subsystem.matrix_W_6_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_7
      save_
  
@@ -8500,6 +8562,7 @@ save_cell_subsystem.matrix_W_6_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_8
      save_
  
@@ -8509,6 +8572,7 @@ save_cell_subsystem.matrix_W_6_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_9
      save_
  
@@ -8518,6 +8582,7 @@ save_cell_subsystem.matrix_W_6_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_10
      save_
  
@@ -8527,6 +8592,7 @@ save_cell_subsystem.matrix_W_6_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_6_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_6_11
      save_
 
@@ -8536,6 +8602,7 @@ save_cell_subsystem.matrix_W_7_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_1
      save_
  
@@ -8545,6 +8612,7 @@ save_cell_subsystem.matrix_W_7_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_2
      save_
  
@@ -8554,6 +8622,7 @@ save_cell_subsystem.matrix_W_7_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_3
      save_
  
@@ -8563,6 +8632,7 @@ save_cell_subsystem.matrix_W_7_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_4
      save_
  
@@ -8572,6 +8642,7 @@ save_cell_subsystem.matrix_W_7_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_5
      save_
  
@@ -8581,6 +8652,7 @@ save_cell_subsystem.matrix_W_7_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_6
      save_
  
@@ -8590,6 +8662,7 @@ save_cell_subsystem.matrix_W_7_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_7
      save_
  
@@ -8599,6 +8672,7 @@ save_cell_subsystem.matrix_W_7_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_8
      save_
  
@@ -8608,6 +8682,7 @@ save_cell_subsystem.matrix_W_7_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_9
      save_
  
@@ -8617,6 +8692,7 @@ save_cell_subsystem.matrix_W_7_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_10
      save_
  
@@ -8626,6 +8702,7 @@ save_cell_subsystem.matrix_W_7_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_7_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_7_11
      save_
 
@@ -8635,6 +8712,7 @@ save_cell_subsystem.matrix_W_8_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_1
      save_
  
@@ -8644,6 +8722,7 @@ save_cell_subsystem.matrix_W_8_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_2
      save_
  
@@ -8653,6 +8732,7 @@ save_cell_subsystem.matrix_W_8_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_3
      save_
  
@@ -8662,6 +8742,7 @@ save_cell_subsystem.matrix_W_8_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_4
      save_
  
@@ -8671,6 +8752,7 @@ save_cell_subsystem.matrix_W_8_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_5
      save_
  
@@ -8680,6 +8762,7 @@ save_cell_subsystem.matrix_W_8_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_6
      save_
  
@@ -8689,6 +8772,7 @@ save_cell_subsystem.matrix_W_8_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_7
      save_
  
@@ -8698,6 +8782,7 @@ save_cell_subsystem.matrix_W_8_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_8
      save_
  
@@ -8707,6 +8792,7 @@ save_cell_subsystem.matrix_W_8_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_9
      save_
  
@@ -8716,6 +8802,7 @@ save_cell_subsystem.matrix_W_8_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_10
      save_
  
@@ -8725,6 +8812,7 @@ save_cell_subsystem.matrix_W_8_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_8_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_8_11
      save_
 
@@ -8734,6 +8822,7 @@ save_cell_subsystem.matrix_W_9_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_1
      save_
  
@@ -8743,6 +8832,7 @@ save_cell_subsystem.matrix_W_9_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_2
      save_
  
@@ -8752,6 +8842,7 @@ save_cell_subsystem.matrix_W_9_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_3
      save_
  
@@ -8761,6 +8852,7 @@ save_cell_subsystem.matrix_W_9_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_4
      save_
  
@@ -8770,6 +8862,7 @@ save_cell_subsystem.matrix_W_9_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_5
      save_
  
@@ -8779,6 +8872,7 @@ save_cell_subsystem.matrix_W_9_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_6
      save_
  
@@ -8788,6 +8882,7 @@ save_cell_subsystem.matrix_W_9_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_7
      save_
  
@@ -8797,6 +8892,7 @@ save_cell_subsystem.matrix_W_9_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_8
      save_
  
@@ -8806,6 +8902,7 @@ save_cell_subsystem.matrix_W_9_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_9
      save_
  
@@ -8815,6 +8912,7 @@ save_cell_subsystem.matrix_W_9_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_10
      save_
  
@@ -8824,6 +8922,7 @@ save_cell_subsystem.matrix_W_9_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_9_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_9_11
      save_
 
@@ -8833,6 +8932,7 @@ save_cell_subsystem.matrix_W_10_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_1
      save_
  
@@ -8842,6 +8942,7 @@ save_cell_subsystem.matrix_W_10_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_2
      save_
  
@@ -8851,6 +8952,7 @@ save_cell_subsystem.matrix_W_10_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_3
      save_
  
@@ -8860,6 +8962,7 @@ save_cell_subsystem.matrix_W_10_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_4
      save_
  
@@ -8869,6 +8972,7 @@ save_cell_subsystem.matrix_W_10_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_5
      save_
  
@@ -8878,6 +8982,7 @@ save_cell_subsystem.matrix_W_10_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_6
      save_
  
@@ -8887,6 +8992,7 @@ save_cell_subsystem.matrix_W_10_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_7
      save_
  
@@ -8896,6 +9002,7 @@ save_cell_subsystem.matrix_W_10_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_8
      save_
  
@@ -8905,6 +9012,7 @@ save_cell_subsystem.matrix_W_10_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_9
      save_
  
@@ -8914,6 +9022,7 @@ save_cell_subsystem.matrix_W_10_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_10
      save_
  
@@ -8923,6 +9032,7 @@ save_cell_subsystem.matrix_W_10_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_10_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_10_11
      save_
 
@@ -8932,6 +9042,7 @@ save_cell_subsystem.matrix_W_11_1
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_1'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_1
      save_
  
@@ -8941,6 +9052,7 @@ save_cell_subsystem.matrix_W_11_2
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_2'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_2
      save_
  
@@ -8950,6 +9062,7 @@ save_cell_subsystem.matrix_W_11_3
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_3'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_3
      save_
  
@@ -8959,6 +9072,7 @@ save_cell_subsystem.matrix_W_11_4
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_4'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_4
      save_
  
@@ -8968,6 +9082,7 @@ save_cell_subsystem.matrix_W_11_5
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_5'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_5
      save_
  
@@ -8977,6 +9092,7 @@ save_cell_subsystem.matrix_W_11_6
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_6'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_6
      save_
  
@@ -8986,6 +9102,7 @@ save_cell_subsystem.matrix_W_11_7
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_7'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_7
      save_
  
@@ -8995,6 +9112,7 @@ save_cell_subsystem.matrix_W_11_8
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_8'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_8
      save_
  
@@ -9004,6 +9122,7 @@ save_cell_subsystem.matrix_W_11_9
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_9'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_9
      save_
  
@@ -9013,6 +9132,7 @@ save_cell_subsystem.matrix_W_11_10
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_10'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_10
      save_
  
@@ -9022,6 +9142,7 @@ save_cell_subsystem.matrix_W_11_11
      loop_
     _alias.definition_id       '_cell_subsystem_matrix_W_11_11'
     _import.get        [{"file":'templ_attr.cif' "save":'matrix_w'}]
+    _name.category_id           cell_subsystem
     _name.object_id             matrix_W_11_11
 save_
 


### PR DESCRIPTION
According to the upcoming version of ITC Volume G, template dictionaries should not contain the `_definition.id`, `_name.object_id` or  `_name.category_id` attributes. This PR introduces the category id directly  to the definitions of `_cell_subsystem.matrix_W_*` to conform to this rule.

A separate PR will need to be done in the `CIF_CORE` repository to remove the `_category.id` attribute from the `matrix_w` save frame.