### PR TITLE
Restrict *_Fourier_wave_vector.seq_id data items to positive integers

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -2796,7 +2796,7 @@ save_ATOM_SITE_DISPLACE_ORTHO
     _definition.id                ATOM_SITE_DISPLACE_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-06-04
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_ORTHO category record
@@ -2864,11 +2864,11 @@ save_ATOM_SITE_DISPLACE_ORTHO
          _atom_site_Fourier_wave_vector.seq_id
          _atom_site_Fourier_wave_vector.q_coeff_seq_id
          _atom_site_Fourier_wave_vector.q_coeff
-            0  [1]  [0]
-            1  [1]  [1]
-            2  [1]  [2]
-            3  [1]  [3]
-            4  [1]  [4]
+            1  [1]  [0]
+            2  [1]  [1]
+            3  [1]  [2]
+            4  [1]  [3]
+            5  [1]  [4]
 
         # - - - - data truncated for brevity - - - -
 
@@ -2892,16 +2892,16 @@ save_ATOM_SITE_DISPLACE_ORTHO
          _atom_sites_ortho.wave_vector_seq_id_list
          _atom_sites_ortho.coeff_cos_list
          _atom_sites_ortho.coeff_sin_list
-         o1  [0 1]      [-3.322 0]        [0 4.323]
-         o2  [0 1]      [-20.803 11.454]  [0 31.365]
-         o3  [0 1]      [0.497 0]         [0 1.774]
-         o4  [0 1]      [0 1.287]         [0 0]
-         o5  [0 1 2]    [0 0.199 0]       [0 0 1.417]
-         o6  [0 1 2]    [-0.870 0 2.020]  [0 -1.611 0]
-         o7  [0 1]      [2.069 0]         [0 3.249]
-         o8  [0 1]      [0 1.414]         [0 0]
-         o9  [0 1 2]    [0 2.271 0]       [0 0 2.267]
-         o10 [0 1 2]    [2.187 0 1.973]   [0 2.785 0]
+         o1  [1 2]      [-3.322 0]        [0 4.323]
+         o2  [1 2]      [-20.803 11.454]  [0 31.365]
+         o3  [1 2]      [0.497 0]         [0 1.774]
+         o4  [1 2]      [0 1.287]         [0 0]
+         o5  [1 2 3]    [0 0.199 0]       [0 0 1.417]
+         o6  [1 2 3]    [-0.870 0 2.020]  [0 -1.611 0]
+         o7  [1 2]      [2.069 0]         [0 3.249]
+         o8  [1 2]      [0 1.414]         [0 0]
+         o9  [1 2 3]    [0 2.271 0]       [0 0 2.267]
+         o10 [1 2 3]    [2.187 0 1.973]   [0 2.785 0]
 
         loop_
          _atom_site_displace_ortho.id
@@ -9669,7 +9669,7 @@ save_ATOM_SITES_ORTHO
     _definition.id                ATOM_SITES_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
 
@@ -9720,11 +9720,11 @@ save_ATOM_SITES_ORTHO
      _atom_site_Fourier_wave_vector.seq_id
      _atom_site_Fourier_wave_vector.q_coeff_seq_id
      _atom_site_Fourier_wave_vector.q_coeff
-        0  [1]  [0]
-        1  [1]  [1]
-        2  [1]  [2]
-        3  [1]  [3]
-        4  [1]  [4]
+        1  [1]  [0]
+        2  [1]  [1]
+        3  [1]  [2]
+        4  [1]  [3]
+        5  [1]  [4]
 
     # - - - - data truncated for brevity - - - -
 
@@ -9742,16 +9742,16 @@ save_ATOM_SITES_ORTHO
      _atom_sites_ortho.wave_vector_seq_id_list
      _atom_sites_ortho.coeff_cos_list
      _atom_sites_ortho.coeff_sin_list
-     o1  [0 1]      [-3.322 0]        [0 4.323]
-     o2  [0 1]      [-20.803 11.454]  [0 31.365]
-     o3  [0 1]      [0.497 0]         [0 1.774]
-     o4  [0 1]      [0 1.287]         [0 0]
-     o5  [0 1 2]    [0 0.199 0]       [0 0 1.417]
-     o6  [0 1 2]    [-0.870 0 2.020]  [0 -1.611 0]
-     o7  [0 1]      [2.069 0]         [0 3.249]
-     o8  [0 1]      [0 1.414]         [0 0]
-     o9  [0 1 2]    [0 2.271 0]       [0 0 2.267]
-     o10 [0 1 2]    [2.187 0 1.973]   [0 2.785 0]
+     o1  [1 2]      [-3.322 0]        [0 4.323]
+     o2  [1 2]      [-20.803 11.454]  [0 31.365]
+     o3  [1 2]      [0.497 0]         [0 1.774]
+     o4  [1 2]      [0 1.287]         [0 0]
+     o5  [1 2 3]    [0 0.199 0]       [0 0 1.417]
+     o6  [1 2 3]    [-0.870 0 2.020]  [0 -1.611 0]
+     o7  [1 2]      [2.069 0]         [0 3.249]
+     o8  [1 2]      [0 1.414]         [0 0]
+     o9  [1 2 3]    [0 2.271 0]       [0 0 2.267]
+     o10 [1 2 3]    [2.187 0 1.973]   [0 2.785 0]
 
     # - - - - data truncated for brevity - - - -
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -860,7 +860,7 @@ save_atom_site_anharmonic_adp_fourier.wave_vector_seq_id
 
     _definition.id
         '_atom_site_anharmonic_ADP_Fourier.wave_vector_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-15
     _description.text
 ;
        A numeric code identifying the wave vectors of the Fourier terms
@@ -875,7 +875,7 @@ save_atom_site_anharmonic_adp_fourier.wave_vector_seq_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -2099,7 +2099,7 @@ save_atom_site_displace_fourier.wave_vector_seq_id
         '_atom_site_displace_Fourier.wave_vector_seq_id'
     _alias.definition_id
         '_atom_site_displace_Fourier_wave_vector_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-15
     _description.text
 ;
       A numeric code identifying the wave vectors of the Fourier terms
@@ -2116,7 +2116,7 @@ save_atom_site_displace_fourier.wave_vector_seq_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -4633,7 +4633,7 @@ save_atom_site_fourier_wave_vector.seq_id
 
     _definition.id                '_atom_site_Fourier_wave_vector.seq_id'
     _alias.definition_id          '_atom_site_Fourier_wave_vector_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-15
     _description.text
 ;
       A numeric code identifying the wave vectors defined in
@@ -4645,7 +4645,7 @@ save_atom_site_fourier_wave_vector.seq_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -5156,7 +5156,7 @@ save_atom_site_occ_fourier.wave_vector_seq_id
 
     _definition.id                '_atom_site_occ_Fourier.wave_vector_seq_id'
     _alias.definition_id          '_atom_site_occ_Fourier_wave_vector_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-15
     _description.text
 ;
       A numeric code identifying the wave vectors of the Fourier terms
@@ -5171,7 +5171,7 @@ save_atom_site_occ_fourier.wave_vector_seq_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -6295,7 +6295,7 @@ save_atom_site_rot_fourier.wave_vector_seq_id
 
     _definition.id                '_atom_site_rot_Fourier.wave_vector_seq_id'
     _alias.definition_id          '_atom_site_rot_Fourier_wave_vector_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-15
     _description.text
 ;
       A numeric code identifying the wave vectors of the Fourier terms
@@ -6310,7 +6310,7 @@ save_atom_site_rot_fourier.wave_vector_seq_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -8072,7 +8072,7 @@ save_atom_site_u_fourier.wave_vector_seq_id
 
     _definition.id                '_atom_site_U_Fourier.wave_vector_seq_id'
     _alias.definition_id          '_atom_site_U_Fourier_wave_vector_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-15
     _description.text
 ;
       A numeric code identifying the wave vectors of the Fourier terms
@@ -8087,7 +8087,7 @@ save_atom_site_u_fourier.wave_vector_seq_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -9832,7 +9832,7 @@ save_
 save_atom_sites_ortho.wave_vector_seq_id_list
 
     _definition.id                '_atom_sites_ortho.wave_vector_seq_id_list'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-15
     _description.text
 ;
       A list of numeric codes that identifies the harmonics chosen for the
@@ -9846,7 +9846,8 @@ save_atom_sites_ortho.wave_vector_seq_id_list
     _type.container               List
     _type.dimension               '[]'
     _type.contents                Integer
-    _enumeration.default          [0]
+    _enumeration.range            1:
+    _enumeration.default          [1]
     _units.code                   none
 
 save_
@@ -18671,10 +18672,13 @@ save_
         Changed the _category_key.name  of DIFFRN_REFLN and REFLN to
         _diffrn_refln.id and _refln.id, respectively.
 
-        2026-06-15
+        2026-06-18
 
         Explicitly deprecated the ATOM_SITES_DISPLACE_FOURIER category.
 
         Changed the content type of _cell.commen_supercell_matrix* data items
         from 'Integer' to 'Real'.
+
+        Restricted the values of _atom_site_Fourier_wave_vector.seq_id and
+        linked data items to positive integers.
 ;


### PR DESCRIPTION
This PR sets the enumeration range of `_atom_site_Fourier_wave_vector.seq_id` and linked data items to `1:` (see https://github.com/COMCIFS/magnetic_dic/pull/69#issuecomment-1945363554 for the reasoning behind this). In several cases the default value was also changed from `0` to `1` to be compatible with the new enumeration range restrictions.