### PR TITLE
Rename the head category from 'MS_GROUP' to 'CIF_MS_HEAD'

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -24,31 +24,30 @@ data_CIF_MS
     _dictionary.formalism        Modulated
     _dictionary.class            Instance
     _dictionary.version          3.2.1
-    _dictionary.date             2024-05-15
+    _dictionary.date             2024-05-17
     _dictionary.uri              http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance  3.13.1
     _dictionary.namespace        ModStruct
     _description.text                   
 ;
-
     The DICTIONARY group encompassing the definitions of data items
     for the study of modulated structures with the Crystallographic 
     Information Framework (CIF).
 ;
 
-save_MS_GROUP
+save_CIF_MS_HEAD
 
-    _definition.id               MS_GROUP
+    _definition.id               CIF_MS_HEAD
     _definition.scope            Category
     _definition.class            Head
-    _definition.update           2024-05-15
+    _definition.update           2024-05-17
     _description.text                   
 ;
-
-    Encompasses groups of categories applicable to modulated structures.
+    The CIF_MS_HEAD category is the top-level category for all categories in
+    the CIF_MS dictionary.
 ;
     _name.category_id            CIF_MS
-    _name.object_id              MS_GROUP
+    _name.object_id              CIF_MS_HEAD
     _import.get
         [
          {'dupl':Ignore  'file':cif_core.dic  'mode':Full  'save':CIF_CORE_HEAD}
@@ -181,7 +180,7 @@ save_ATOM_SITE_DISPLACE_FOURIER
     _definition.id               ATOM_SITE_DISPLACE_FOURIER
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -195,7 +194,7 @@ save_ATOM_SITE_DISPLACE_FOURIER
       coefficients of each Fourier component belong to the child category
       ATOM_SITE_DISPLACE_FOURIER_PARAM and may be listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_FOURIER
     loop_
     _category_key.name           '_atom_site_displace_Fourier.id'
@@ -616,7 +615,7 @@ save_ATOM_SITE_DISPLACE_LEGENDRE
     _definition.id               ATOM_SITE_DISPLACE_LEGENDRE
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2017-09-28
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -661,7 +660,7 @@ save_ATOM_SITE_DISPLACE_LEGENDRE
                   Discontinuous modulation functions and their application for 
                   analysis of modulated structures with the computing system JANA2006
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_LEGENDRE
     loop_
       _category_key.name         '_atom_site_displace_Legendre.id'
@@ -821,7 +820,7 @@ save_ATOM_SITE_DISPLACE_LEGENDRE_PARAM
     _definition.id               ATOM_SITE_DISPLACE_LEGENDRE_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -834,7 +833,7 @@ save_ATOM_SITE_DISPLACE_LEGENDRE_PARAM
       rotational part would appear in a separate list of items
       belonging to the ATOM_SITE_ROT_LEGENDRE_PARAM category. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_LEGENDRE_PARAM
     loop_
       _category_key.name         '_atom_site_displace_Legendre_param.id'
@@ -897,7 +896,7 @@ save_ATOM_SITE_DISPLACE_ORTHO
     _definition.id               ATOM_SITE_DISPLACE_ORTHO
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -920,7 +919,7 @@ save_ATOM_SITE_DISPLACE_ORTHO
       information) using the data items defined in the categories 
       ATOM_SITE_DISPLACE_FOURIER and ATOM_SITE_DISPLACE_FOURIER_PARAM.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_ORTHO
     loop_
       _category_key.name         '_atom_site_displace_ortho.id'
@@ -1086,7 +1085,7 @@ save_ATOM_SITE_DISPLACE_ORTHO_PARAM
     _definition.id               ATOM_SITE_DISPLACE_ORTHO_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -1100,7 +1099,7 @@ save_ATOM_SITE_DISPLACE_ORTHO_PARAM
       belonging to the ATOM_SITE_ROT_ORTHO_PARAM category. 
 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_ORTHO_PARAM
     loop_
       _category_key.name         '_atom_site_displace_ortho_param.id'
@@ -1160,7 +1159,7 @@ save_ATOM_SITE_DISPLACE_SPECIAL_FUNC
     _definition.id               ATOM_SITE_DISPLACE_SPECIAL_FUNC
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -1198,7 +1197,7 @@ save_ATOM_SITE_DISPLACE_SPECIAL_FUNC
                   Discontinuous modulation functions and their application for 
                   analysis of modulated structures with the computing system JANA2006
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_SPECIAL_FUNC
     loop_
     _category_key.name           '_atom_site_displace_special_func.atom_site_label'
@@ -1735,7 +1734,7 @@ save_ATOM_SITE_DISPLACE_XHARM
     _definition.id               ATOM_SITE_DISPLACE_XHARM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -1779,7 +1778,7 @@ save_ATOM_SITE_DISPLACE_XHARM
                   Discontinuous modulation functions and their application for 
                   analysis of modulated structures with the computing system JANA2006 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_XHARM
     loop_
       _category_key.name         '_atom_site_displace_xharm.id'
@@ -1940,7 +1939,7 @@ save_ATOM_SITE_DISPLACE_XHARM_PARAM
     _definition.id               ATOM_SITE_DISPLACE_XHARM_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -1953,7 +1952,7 @@ save_ATOM_SITE_DISPLACE_XHARM_PARAM
       rotational part would appear in a separate list of items
       belonging to the ATOM_SITE_ROT_XHARM_PARAM category. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_DISPLACE_XHARM_PARAM
     loop_
       _category_key.name         '_atom_site_displace_xharm_param.id'
@@ -2012,7 +2011,7 @@ save_ATOM_SITE_FOURIER_WAVE_VECTOR
     _definition.id               ATOM_SITE_FOURIER_WAVE_VECTOR
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -2020,7 +2019,7 @@ save_ATOM_SITE_FOURIER_WAVE_VECTOR
       details about the wave vectors of the Fourier terms used in the
       structural model.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_FOURIER_WAVE_VECTOR
     loop_
     _category_key.name          '_atom_site_Fourier_wave_vector.seq_id'
@@ -2833,7 +2832,7 @@ save_ATOM_SITE_OCC_FOURIER
     _definition.id               ATOM_SITE_OCC_FOURIER
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -2843,7 +2842,7 @@ save_ATOM_SITE_OCC_FOURIER
       coefficients of each Fourier component belong to the child category
       ATOM_SITE_OCC_FOURIER_PARAM and may be listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_FOURIER
     loop_
         _category_key.name      '_atom_site_occ_Fourier.id'
@@ -3163,7 +3162,7 @@ save_ATOM_SITE_OCC_LEGENDRE
     _definition.id               ATOM_SITE_OCC_LEGENDRE
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -3174,7 +3173,7 @@ save_ATOM_SITE_OCC_LEGENDRE
       function belong to the category ATOM_SITE_OCC_LEGENDRE_PARAM and 
       are listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_LEGENDRE
     loop_
       _category_key.name         '_atom_site_occ_Legendre.id'
@@ -3272,7 +3271,7 @@ save_ATOM_SITE_OCC_LEGENDRE_PARAM
     _definition.id               ATOM_SITE_OCC_LEGENDRE_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -3281,7 +3280,7 @@ save_ATOM_SITE_OCC_LEGENDRE_PARAM
       functions defined in ATOM_SITE_OCC_LEGENDRE and used to 
       describe the occupational modulation of an atom or rigid group. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_LEGENDRE_PARAM
     loop_
       _category_key.name         '_atom_site_occ_Legendre_param.id'
@@ -3334,7 +3333,7 @@ save_ATOM_SITE_OCC_ORTHO
     _definition.id               ATOM_SITE_OCC_ORTHO
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -3353,7 +3352,7 @@ save_ATOM_SITE_OCC_ORTHO
       information) using the data items defined in the categories  
       ATOM_SITE_OCC_FOURIER and ATOM_SITE_OCC_FOURIER_PARAM.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_ORTHO
     loop_
       _category_key.name         '_atom_site_occ_ortho.id'
@@ -3454,7 +3453,7 @@ save_ATOM_SITE_OCC_ORTHO_PARAM
     _definition.id               ATOM_SITE_OCC_ORTHO_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -3463,7 +3462,7 @@ save_ATOM_SITE_OCC_ORTHO_PARAM
       functions defined in ATOM_SITE_OCC_ORTHO and used to 
       describe the occupational modulation of an atom or rigid group. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_ORTHO_PARAM
     loop_
       _category_key.name         '_atom_site_occ_ortho_param.id'
@@ -3518,7 +3517,7 @@ save_ATOM_SITE_OCC_SPECIAL_FUNC
     _definition.id               ATOM_SITE_OCC_SPECIAL_FUNC
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -3557,7 +3556,7 @@ save_ATOM_SITE_OCC_SPECIAL_FUNC
                   analysis of modulated structures with the computing system JANA2006
 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_SPECIAL_FUNC
     loop_
         _category_key.name       '_atom_site_occ_special_func.atom_site_label'
@@ -3724,7 +3723,7 @@ save_ATOM_SITE_OCC_XHARM
     _definition.id               ATOM_SITE_OCC_XHARM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -3734,7 +3733,7 @@ save_ATOM_SITE_OCC_XHARM
       a crenel function. The coefficients of each x-harmonic function belong 
       to the category ATOM_SITE_OCC_XHARM_PARAM and are listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_XHARM
     loop_
       _category_key.name         '_atom_site_occ_xharm.id'
@@ -3811,7 +3810,7 @@ save_ATOM_SITE_OCC_XHARM_PARAM
     _definition.id               ATOM_SITE_OCC_XHARM_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -3819,7 +3818,7 @@ save_ATOM_SITE_OCC_XHARM_PARAM
       about the coefficients of the x-harmonics defined in ATOM_SITE_OCC_XHARM 
       and used to describe the occupational modulation of an atom or rigid group. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_OCC_XHARM_PARAM
     loop_
       _category_key.name         '_atom_site_occ_xharm_param.id'
@@ -3892,7 +3891,7 @@ save_ATOM_SITE_PHASON
     _definition.id               ATOM_SITE_PHASON
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -3902,7 +3901,7 @@ save_ATOM_SITE_PHASON
       (for example, JANA2006) allow for this (theoretically dubious)
       atom-dependent phason treatment.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_PHASON
     loop_
         _category_key.name       '_atom_site_phason.atom_site_label'
@@ -4007,7 +4006,7 @@ save_ATOM_SITE_ROT_FOURIER
     _definition.id               ATOM_SITE_ROT_FOURIER
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -4020,7 +4019,7 @@ save_ATOM_SITE_ROT_FOURIER
       to the child category ATOM_SITE_ROT_FOURIER_PARAM and may be listed
       separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_FOURIER
     loop_
         _category_key.name      '_atom_site_rot_Fourier.atom_site_label'
@@ -4402,7 +4401,7 @@ save_ATOM_SITE_ROT_LEGENDRE
     _definition.id               ATOM_SITE_ROT_LEGENDRE
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -4416,7 +4415,7 @@ save_ATOM_SITE_ROT_LEGENDRE
       of each Legendre function belong to the category
       ATOM_SITE_ROT_LEGENDRE_PARAM and are listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_LEGENDRE
     loop_
       _category_key.name         '_atom_site_rot_Legendre.id'
@@ -4578,7 +4577,7 @@ save_ATOM_SITE_ROT_LEGENDRE_PARAM
     _definition.id               ATOM_SITE_ROT_LEGENDRE_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -4591,7 +4590,7 @@ save_ATOM_SITE_ROT_LEGENDRE_PARAM
       translational part would appear in a separate list of items
       belonging to the ATOM_SITE_DISPLACE_LEGENDRE_PARAM category. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_LEGENDRE_PARAM
     loop_
       _category_key.name         '_atom_site_rot_Legendre_param.id'
@@ -4651,7 +4650,7 @@ save_ATOM_SITE_ROT_ORTHO
     _definition.id               ATOM_SITE_ROT_ORTHO
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -4674,7 +4673,7 @@ save_ATOM_SITE_ROT_ORTHO
       information) using the data items defined in the categories 
       ATOM_SITE_ROT_FOURIER and ATOM_SITE_ROT_FOURIER_PARAM.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_ORTHO
     loop_
       _category_key.name         '_atom_site_rot_ortho.id'
@@ -4840,7 +4839,7 @@ save_ATOM_SITE_ROT_ORTHO_PARAM
     _definition.id               ATOM_SITE_ROT_ORTHO_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -4854,7 +4853,7 @@ save_ATOM_SITE_ROT_ORTHO_PARAM
       belonging to the ATOM_SITE_DISPLACE_ORTHO_PARAM category. 
 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_ORTHO_PARAM
     loop_
       _category_key.name         '_atom_site_rot_ortho_param.id'
@@ -4914,7 +4913,7 @@ save_ATOM_SITE_ROT_SPECIAL_FUNC
     _definition.id               ATOM_SITE_ROT_SPECIAL_FUNC
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -4955,7 +4954,7 @@ rigid groups.
                   analysis of modulated structures with the computing system JANA2006
 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_SPECIAL_FUNC
     _category_key.name           '_atom_site_rot_special_func.atom_site_label'
 
@@ -5488,7 +5487,7 @@ save_ATOM_SITE_ROT_XHARM
     _definition.id               ATOM_SITE_ROT_XHARM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -5502,7 +5501,7 @@ save_ATOM_SITE_ROT_XHARM
       of each x-harmonic function belong to the category
       ATOM_SITE_ROT_XHARM_PARAM and are listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_XHARM
     loop_
       _category_key.name         '_atom_site_rot_xharm.id'
@@ -5662,7 +5661,7 @@ save_ATOM_SITE_ROT_XHARM_PARAM
     _definition.id               ATOM_SITE_ROT_XHARM_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -5675,7 +5674,7 @@ save_ATOM_SITE_ROT_XHARM_PARAM
       translational part would appear in a separate list of items
       belonging to the ATOM_SITE_DISPLACE_XHARM_PARAM category. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_ROT_XHARM_PARAM
     loop_
       _category_key.name         '_atom_site_rot_xharm_param.id'
@@ -5735,7 +5734,7 @@ save_ATOM_SITE_U_FOURIER
     _definition.id               ATOM_SITE_U_FOURIER
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -5743,7 +5742,7 @@ save_ATOM_SITE_U_FOURIER
       about the Fourier components describing the modulation of the
       ADPs in a modulated structure.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_U_FOURIER
     loop_
         _category_key.name       '_atom_site_U_Fourier.id'
@@ -6104,7 +6103,7 @@ save_ATOM_SITE_U_LEGENDRE
     _definition.id               ATOM_SITE_U_LEGENDRE
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -6115,7 +6114,7 @@ save_ATOM_SITE_U_LEGENDRE
       of each Legendre function belong to the category
       ATOM_SITE_U_LEGENDRE_PARAM and are listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_U_LEGENDRE
     loop_
       _category_key.name         '_atom_site_u_Legendre.id'
@@ -6245,7 +6244,7 @@ save_ATOM_SITE_U_LEGENDRE_PARAM
     _definition.id               ATOM_SITE_U_LEGENDRE_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -6254,7 +6253,7 @@ save_ATOM_SITE_U_LEGENDRE_PARAM
       functions defined in ATOM_SITE_U_LEGENDRE and used to 
       describe the ADP modulation of an atom. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_U_LEGENDRE_PARAM
     loop_
       _category_key.name         '_atom_site_U_Legendre_param.id'
@@ -6309,7 +6308,7 @@ save_ATOM_SITE_U_ORTHO
     _definition.id               ATOM_SITE_U_ORTHO
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -6324,7 +6323,7 @@ save_ATOM_SITE_U_ORTHO
       of each orthogonalized function belong to the category
       ATOM_SITE_U_ORTHO_PARAM and are listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_U_ORTHO
     loop_
       _category_key.name         '_atom_site_U_ortho.id'
@@ -6461,7 +6460,7 @@ save_ATOM_SITE_U_ORTHO_PARAM
     _definition.id               ATOM_SITE_U_ORTHO_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -6470,7 +6469,7 @@ save_ATOM_SITE_U_ORTHO_PARAM
       functions defined in ATOM_SITE_U_ORTHO and used to 
       describe the ADP modulation of an atom. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_U_ORTHO_PARAM
     loop_
       _category_key.name         '_atom_site_U_ortho_param.id'
@@ -6525,7 +6524,7 @@ save_ATOM_SITE_U_XHARM
     _definition.id               ATOM_SITE_U_XHARM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -6536,7 +6535,7 @@ save_ATOM_SITE_U_XHARM
       of each x-harmonic function belong to the category
       ATOM_SITE_U_XHARM_PARAM and are listed separately.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_U_XHARM
     loop_
       _category_key.name         '_atom_site_U_xharm.id'
@@ -6665,7 +6664,7 @@ save_ATOM_SITE_U_XHARM_PARAM
     _definition.id               ATOM_SITE_U_XHARM_PARAM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -6674,7 +6673,7 @@ save_ATOM_SITE_U_XHARM_PARAM
       defined in ATOM_SITE_U_XHARM and used to describe the ADP 
       modulation of an atom. 
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITE_U_XHARM_PARAM
     loop_
       _category_key.name         '_atom_site_U_xharm_param.id'
@@ -6729,7 +6728,7 @@ save_ATOM_SITES_AXES
     _definition.id               ATOM_SITES_AXES
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2017-03-11
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -6739,7 +6738,7 @@ save_ATOM_SITES_AXES
       for individual atom sites are described by data items in
       the ATOM_SITE_DISPLACE_* and ATOM_SITE_ROT_* categories.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITES_AXES
     loop_
       _category_key.name         '_atom_sites_axes.matrix_seq_id'
@@ -7088,7 +7087,7 @@ save_ATOM_SITES_DISPLACE_FOURIER
     _definition.id               ATOM_SITES_DISPLACE_FOURIER
     _definition.scope            Category
     _definition.class            Set
-    _definition.update           2017-03-11
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -7098,7 +7097,7 @@ save_ATOM_SITES_DISPLACE_FOURIER
       Details for individual atom sites are described by data items in
       the ATOM_SITE_DISPLACE_FOURIER category.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITES_DISPLACE_FOURIER
 save_
 
@@ -7141,14 +7140,14 @@ save_ATOM_SITES_MODULATION
     _definition.id               ATOM_SITES_MODULATION
     _definition.scope            Category
     _definition.class            Set
-    _definition.update           2017-03-11
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
       Data items in the ATOM_SITES_MODULATION category record details
       common to the modulation of atom sites in a modulated structure.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITES_MODULATION
 
 save_
@@ -7407,7 +7406,7 @@ save_ATOM_SITES_ORTHO
     _definition.id               ATOM_SITES_ORTHO
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
  
@@ -7430,7 +7429,7 @@ save_ATOM_SITES_ORTHO
                   Discontinuous modulation functions and their application for 
                   analysis of modulated structures with the computing system JANA2006
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITES_ORTHO
     loop_
       _category_key.name         '_atom_sites_ortho.func_id'
@@ -7595,7 +7594,7 @@ save_ATOM_SITES_ROT_FOURIER
     _definition.id               ATOM_SITES_ROT_FOURIER
     _definition.scope            Category
     _definition.class            Set
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -7606,7 +7605,7 @@ save_ATOM_SITES_ROT_FOURIER
       Details for individual atom sites are described by data items in
       the ATOM_SITES_ROT_FOURIER category.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              ATOM_SITES_ROT_FOURIER
 
 save_
@@ -7745,7 +7744,7 @@ save_CELL_SUBSYSTEM
     _definition.id               CELL_SUBSYSTEM
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -7753,7 +7752,7 @@ save_CELL_SUBSYSTEM
       the crystallographic cell parameters of each subsystem present in
       a composite.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              CELL_SUBSYSTEM
     loop_
         _category_key.name       '_cell_subsystem.code'
@@ -9154,14 +9153,14 @@ save_CELL_SUBSYSTEMS
     _definition.id               CELL_SUBSYSTEMS
     _definition.scope            Category
     _definition.class            Set
-    _definition.update           2016-11-17
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
       Data items in the CELL_SUBSYSTEMS category describe overall aspects
       of the subsystems present in a composite.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              CELL_SUBSYSTEMS
 
 save_
@@ -9196,7 +9195,7 @@ save_CELL_WAVE_VECTOR
     _definition.id               cell_wave_vector
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -9207,7 +9206,7 @@ save_CELL_WAVE_VECTOR
       over all wave vectors. In this version of the dictionary, the
       index i has been restricted to be less than 9.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              CELL_WAVE_VECTOR
 	loop_
     _category_key.name           '_cell_wave_vector.seq_id'
@@ -9391,7 +9390,7 @@ save_CELL_WAVE_VECTORS
     _definition.id               CELL_WAVE_VECTORS
     _definition.scope            Category
     _definition.class            Set
-    _definition.update           2016-11-17
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -9402,7 +9401,7 @@ save_CELL_WAVE_VECTORS
       over all wave vectors. In this version of the dictionary, the
       index i has been restricted to be less than 9.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              CELL_WAVE_VECTORS
 
 save_
@@ -9565,7 +9564,7 @@ save_DIFFRN_REFLN
     _definition.id               DIFFRN_REFLN
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2016-11-17
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -9579,7 +9578,7 @@ save_DIFFRN_REFLN
       of the core CIF dictionary definitions to the indexing of
       diffraction intensities by higher-dimensional components.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              DIFFRN_REFLN
     loop_
       _category_key.name
@@ -10208,7 +10207,7 @@ save_DIFFRN_STANDARD_REFLN
     _definition.id               DIFFRN_STANDARD_REFLN
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -10221,7 +10220,7 @@ save_DIFFRN_STANDARD_REFLN
       to the indexing of standard reflections by
       higher-dimensional components.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              DIFFRN_STANDARD_REFLN
     loop_
       _category_key.name
@@ -10886,7 +10885,7 @@ save_GEOM_ANGLE
     _definition.id               GEOM_ANGLE
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -10902,7 +10901,7 @@ save_GEOM_ANGLE
       calculation method is not explicit in either this
       dictionary or the core.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              GEOM_ANGLE
     loop_
        _category_key.name
@@ -11597,7 +11596,7 @@ save_REFINE
     _definition.id               REFINE
     _definition.scope            Category
     _definition.class            Set
-    _definition.update           2016-11-17
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -11607,7 +11606,7 @@ save_REFINE
       dictionary and are specific to the refinement of
       modulated structures.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              REFINE
 
 save_
@@ -11729,7 +11728,7 @@ save_REFLN
     _definition.id               REFLN
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -11743,7 +11742,7 @@ save_REFLN
       indexing of reflections used in the refinement by
       higher-dimensional components.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              REFLN
     loop_
       _category_key.name
@@ -11950,7 +11949,7 @@ save_REFLNS
     _definition.id               REFLNS
     _definition.scope            Category
     _definition.class            Set
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -11964,7 +11963,7 @@ save_REFLNS
       checks on the range of values recorded for each of the
       additional Miller indices given in the REFLN category.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              REFLNS
 save_
 
@@ -12546,7 +12545,7 @@ save_SPACE_GROUP_SYMOP
     _definition.id               SPACE_GROUP_SYMOP
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2014-06-27
+    _definition.update           2024-05-17
     _description.text                   
 ;
 
@@ -12558,7 +12557,7 @@ save_SPACE_GROUP_SYMOP
       category, but include the _ssg_ flag to indicate their
       dimensionality of > 3.
 ;
-    _name.category_id            MS_GROUP
+    _name.category_id            CIF_MS_HEAD
     _name.object_id              SPACE_GROUP_SYMOP
     _category_key.name           '_space_group_symop.ssg_id'
 
@@ -12858,7 +12857,7 @@ loop_
      Returned all additional indices to main dictionary, removed category_id
      from templates(James Hester)
 ;
-         3.2.1    2024-05-15
+         3.2.1    2024-05-17
 ;
      Corrected a typo in the definition of the _geom_torsion.angle data item.
 
@@ -12867,4 +12866,6 @@ loop_
 
      Updated the CIF_CORE dictionary import statement with the new Head
      category name.
+
+     Renamed the head category from 'MS_GROUP' to 'CIF_MS_HEAD'.
 ;

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -43,8 +43,9 @@ save_CIF_MS_HEAD
     _definition.update           2024-05-17
     _description.text                   
 ;
-    The CIF_MS_HEAD category is the top-level category for all categories in
-    the CIF_MS dictionary.
+    The CIF_MS_HEAD category is the top-level category for all categories
+    in the CIF_MS dictionary. Head categories from other dictionaries are
+    reparented to this category.
 ;
     _name.category_id            CIF_MS
     _name.object_id              CIF_MS_HEAD


### PR DESCRIPTION
This PR renames the head category as discussed in issue https://github.com/COMCIFS/cif_core/issues/488.

Note that since the head category name is used in the import statements of the `CIF_MAG` dictionary, it should be updated as soon as possible after merging the PR. I will provide a link to the relevant PR for the `CIF_MAG` dictionary in a separate comment.