### PR TITLE
Update save frame name in the twinCIF dictionary import statement

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -24,7 +24,7 @@ data_CIF_MS
     _dictionary.formalism         Modulated
     _dictionary.class             Instance
     _dictionary.version           3.2.5
-    _dictionary.date              2025-10-31
+    _dictionary.date              2025-12-05
     _dictionary.uri               http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance   4.1.0
     _dictionary.namespace         ModStruct
@@ -40,7 +40,7 @@ save_CIF_MS_HEAD
     _definition.id                CIF_MS_HEAD
     _definition.scope             Category
     _definition.class             Head
-    _definition.update            2024-08-09
+    _definition.update            2025-12-05
     _description.text
 ;
       Encompasses groups of categories applicable to modulated structures.
@@ -52,7 +52,7 @@ save_CIF_MS_HEAD
         [
          {'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
           'save':MULTIBLOCK_CORE}
-         {'dupl':Ignore  'file':cif_twin.dic  'mode':Full  'save':TWIN_GROUP}
+         {'dupl':Ignore  'file':cif_twin.dic  'mode':Full  'save':CIF_TWIN_HEAD}
         ]
 
 save_
@@ -18589,7 +18589,7 @@ save_
         2024-12-12
         Technical fixes (JRH)
 ;
-         3.2.5                    2025-10-31
+         3.2.5                    2025-12-05
 ;
         _SPECIAL_FUNC categories, replaced by:
         _DISPLACE_SAWTOOTH


### PR DESCRIPTION
The save frame was renamed upstream from TWIN_GROUP to CIF_TWIN_HEAD