### PR TITLE
Add structure keys to _atom_site_*

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -227,6 +227,9 @@ save_ATOM_SITE_ANHARMONIC_ADP
       described by items belong to the ATOM_SITE_ANHARMONIC_ADP_FOURIER
       category.
 
+      _atom_site_anharmonic_ADP.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
+
       References: Kuznetsov, P.I., Stratonovich, R.L. & Tikhonov, V.I. (1960).
                   Theory of Probability & Its Applications 5(1), 80-97.
                   DOI 10.1137/1105007
@@ -542,6 +545,9 @@ save_atom_site_anharmonic_adp.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_anharmonic_ADP
     _name.object_id               structure_id
@@ -659,6 +665,9 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER
        Data items in the ATOM_SITE_ANHARMONIC_ADP_FOURIER category record
        details about the Fourier components of the tensors that describe
        the modulation of the anharmonic ADPs in a modulated structure.
+
+       _atom_site_anharmonic_ADP_Fourier.structure_id may be omitted if
+       only one _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_FOURIER
@@ -790,6 +799,9 @@ save_atom_site_anharmonic_adp_fourier.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_anharmonic_ADP_Fourier
     _name.object_id               structure_id
@@ -954,6 +966,9 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
           for all atoms in the group. t is an arbitrary phase, irrelevant for
           incommensurate modulated structures, but essential in the
           commensurate case (see _atom_sites_modulation.global_phase_t_).
+
+          _atom_site_anharmonic_ADP_Fourier_param.structure_id may be omitted
+          if only one _structure.id is present in the same data block.
 ;
     _name.category_id             ATOM_SITE_ANHARMONIC_ADP_FOURIER
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
@@ -1274,6 +1289,9 @@ save_atom_site_anharmonic_adp_fourier_param.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_anharmonic_ADP_Fourier_param
     _name.object_id               structure_id
@@ -1297,6 +1315,9 @@ save_ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
       details about the Legendre polynomials used to describe the
       modulations of the anharmonic ADP tensor elements when the atomic
       domain of a given atom is restricted by a crenel function.
+
+      _atom_site_anharmonic_ADP_Legendre.structure_id may be omitted if
+      only one _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
@@ -1415,6 +1436,9 @@ save_atom_site_anharmonic_adp_legendre.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_anharmonic_ADP_Legendre
     _name.object_id               structure_id
@@ -1539,6 +1563,9 @@ save_ATOM_SITE_ANHARMONIC_ADP_ORTHO
       selecting Fourier harmonics until the desired degree of orthogonality
       and completeness is reached (see
       _atom_site_occ_crenel.ortho_eps).
+
+      _atom_site_anharmonic_ADP_ortho.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_ORTHO
@@ -1662,6 +1689,9 @@ save_atom_site_anharmonic_adp_ortho.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_anharmonic_ADP_ortho
     _name.object_id               structure_id
@@ -1781,6 +1811,9 @@ save_ATOM_SITE_ANHARMONIC_ADP_XHARM
       details about the x-harmonics used to describe the  modulations of
       the anharmonic ADP tensor elements when the atomic domain of a
       given atom is restricted by a crenel function.
+
+      _atom_site_anharmonic_ADP_xharm.structure_id may be omitted if only
+      one _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_XHARM
@@ -1898,6 +1931,9 @@ save_atom_site_anharmonic_adp_xharm.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_anharmonic_ADP_xharm
     _name.object_id               structure_id
@@ -2021,6 +2057,9 @@ save_ATOM_SITE_DISPLACE_FOURIER
       ATOM_SITE_ROT_FOURIER category. The (in general complex)
       coefficients of each Fourier component belong to the child category
       ATOM_SITE_DISPLACE_FOURIER_PARAM and may be listed separately.
+
+      _atom_site_displace_Fourier.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_FOURIER
@@ -2241,6 +2280,9 @@ save_atom_site_displace_fourier.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_displace_Fourier
     _name.object_id               structure_id
@@ -2324,6 +2366,9 @@ save_ATOM_SITE_DISPLACE_FOURIER_PARAM
       Use of _atom_sites_displace_Fourier.axes_description is DEPRECATED
       and retained only for backward compatibility. Notice that in this
       case displacements were expressed in angstroms.
+
+      _atom_site_displace_Fourier_param.structure_id may be omitted if only
+      one _structure.id is present in the same data block.
 ;
     _name.category_id             ATOM_SITE_DISPLACE_FOURIER
     _name.object_id               ATOM_SITE_DISPLACE_FOURIER_PARAM
@@ -2655,6 +2700,9 @@ save_atom_site_displace_fourier_param.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_displace_Fourier_param
     _name.object_id               structure_id
@@ -2713,6 +2761,9 @@ save_ATOM_SITE_DISPLACE_LEGENDRE
       either of the unit cell axes or of the axes defined by the items
       belonging to the ATOM_SITES_AXES category, through
       _atom_site_displace_Legendre.matrix_seq_id.
+
+      _atom_site_displace_Legendre.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 
       References: Petricek, V., Van Der Lee & Evain, M. (1995).
                   Acta Cryst. A51, 529-535. DOI 10.1107/S0108767395000365
@@ -2987,6 +3038,9 @@ save_atom_site_displace_legendre.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_displace_Legendre
     _name.object_id               structure_id
@@ -3028,6 +3082,9 @@ save_ATOM_SITE_DISPLACE_ORTHO
       information about the orthogonalized set of functions) using the
       data items defined in the categories ATOM_SITE_DISPLACE_FOURIER
       and ATOM_SITE_DISPLACE_FOURIER_PARAM.
+
+      _atom_site_displace_ortho.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_ORTHO
@@ -3322,6 +3379,9 @@ save_atom_site_displace_ortho.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_displace_ortho
     _name.object_id               structure_id
@@ -3375,6 +3435,9 @@ save_ATOM_SITE_DISPLACE_SAWTOOTH
       either of the unit cell axes or of the axes defined by the items
       belonging to the ATOM_SITES_AXES category, through
       _atom_site_displace_sawtooth.matrix_seq_id.
+
+      _atom_site_displace_sawtooth.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 
       References: Petricek, V., Dusek, M. & Palatinus, L. (2014).
                   Z. Kristallogr. 229(5), 345-352.  DOI 10.1515/zkri-2014-1737
@@ -3735,6 +3798,9 @@ save_atom_site_displace_sawtooth.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_displace_sawtooth
     _name.object_id               structure_id
@@ -3827,6 +3893,9 @@ save_ATOM_SITE_DISPLACE_XHARM
       either of the unit cell axes or of the axes defined by the items
       belonging to the ATOM_SITES_AXES category, through
       _atom_site_displace_xharm.matrix_seq_id.
+
+      _atom_site_displace_xharm.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 
       References: Petricek, V., Van Der Lee & Evain, M. (1995).
                   Acta Cryst. A51, 529-535. DOI 10.1107/S0108767395000365
@@ -4113,6 +4182,9 @@ save_atom_site_displace_xharm.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_displace_xharm
     _name.object_id               structure_id
@@ -4162,6 +4234,9 @@ save_ATOM_SITE_DISPLACE_ZIGZAG
 
       For more information and references see the description of the
       ATOM_SITE_DISPLACE_SAWTOOTH category.
+
+      _atom_site_displace_zigzag.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_ZIGZAG
@@ -4337,6 +4412,9 @@ save_atom_site_displace_zigzag.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_displace_zigzag
     _name.object_id               structure_id
@@ -5120,6 +5198,9 @@ save_ATOM_SITE_OCC_CRENEL
 
       For more information and references see the description of the
       ATOM_SITE_DISPLACE_SAWTOOTH category.
+
+      _atom_site_occ_crenel.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_CRENEL
@@ -5290,6 +5371,9 @@ save_atom_site_occ_crenel.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_occ_crenel
     _name.object_id               structure_id
@@ -5355,6 +5439,9 @@ save_ATOM_SITE_OCC_FOURIER
       the atom sites in a modulated structure. The (in general complex)
       coefficients of each Fourier component belong to the child category
       ATOM_SITE_OCC_FOURIER_PARAM and may be listed separately.
+
+      _atom_site_occ_Fourier.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_FOURIER
@@ -5490,6 +5577,9 @@ save_atom_site_occ_fourier.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_occ_Fourier
     _name.object_id               structure_id
@@ -5556,6 +5646,9 @@ save_ATOM_SITE_OCC_FOURIER_PARAM
       for all atoms in the group. t is an arbitrary phase, irrelevant for
       incommensurate modulated structures, but essential in the commensurate
       case (see _atom_sites_modulation.global_phase_t_).
+
+      _atom_site_occ_Fourier_param.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             ATOM_SITE_OCC_FOURIER
     _name.object_id               ATOM_SITE_OCC_FOURIER_PARAM
@@ -5863,6 +5956,9 @@ save_atom_site_occ_fourier_param.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_occ_Fourier_param
     _name.object_id               structure_id
@@ -5887,6 +5983,9 @@ save_ATOM_SITE_OCC_LEGENDRE
       modulations when the atomic domain of a given atom or rigid group
       is restricted  by a crenel function. See ATOM_SITE_DISPLACE_LEGENDRE
       for more detailed information.
+
+      _atom_site_occ_Legendre.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_LEGENDRE
@@ -6003,6 +6102,9 @@ save_atom_site_occ_legendre.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_occ_Legendre
     _name.object_id               structure_id
@@ -6036,6 +6138,9 @@ save_ATOM_SITE_OCC_ORTHO
       information about the orthogonalized functions) using the data items
       defined in the categories ATOM_SITE_OCC_FOURIER and
       ATOM_SITE_OCC_FOURIER_PARAM.
+
+      _atom_site_occ_ortho.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_ORTHO
@@ -6155,6 +6260,9 @@ save_atom_site_occ_ortho.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_occ_ortho
     _name.object_id               structure_id
@@ -6179,6 +6287,9 @@ save_ATOM_SITE_OCC_XHARM
       the atomic domain of a given atom or rigid group is restricted by
       a crenel function.  See ATOM_SITE_DISPLACE_XHARM for more detailed
       information.
+
+      _atom_site_occ_xharm.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_XHARM
@@ -6295,6 +6406,9 @@ save_atom_site_occ_xharm.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_occ_xharm
     _name.object_id               structure_id
@@ -6319,6 +6433,9 @@ save_ATOM_SITE_PHASON
       correction is intended to be overall, some refinement programs
       (for example, JANA) allow for this (theoretically dubious)
       atom-dependent phason treatment.
+
+      _atom_site_phason.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_PHASON
@@ -6436,6 +6553,9 @@ save_atom_site_phason.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_phason
     _name.object_id               structure_id
@@ -6463,6 +6583,9 @@ save_ATOM_SITE_ROT_FOURIER
       general complex) coefficients of each Fourier component belong
       to the child category ATOM_SITE_ROT_FOURIER_PARAM and may be listed
       separately.
+
+      _atom_site_rot_Fourier.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_FOURIER
@@ -6768,6 +6891,9 @@ save_atom_site_rot_fourier.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_rot_Fourier
     _name.object_id               structure_id
@@ -6846,6 +6972,9 @@ save_ATOM_SITE_ROT_FOURIER_PARAM
 
       Use of _atom_sites_rot_Fourier.axes_description is DEPRECATED and
       retained only by for backward compatibility.
+
+      _atom_site_rot_Fourier_param.structure_id may be omitted if only
+      one _structure.id is present in the same data block.
 ;
     _name.category_id             ATOM_SITE_ROT_FOURIER
     _name.object_id               ATOM_SITE_ROT_FOURIER_PARAM
@@ -7294,6 +7423,9 @@ save_atom_site_rot_fourier_param.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_rot_Fourier_param
     _name.object_id               structure_id
@@ -7320,6 +7452,9 @@ save_ATOM_SITE_ROT_LEGENDRE
       category would only include the rotational part of the modulation.
       The translational part would appear in a separate list of items
       belonging to the ATOM_SITE_DISPLACE_LEGENDRE category.
+
+      _atom_site_rot_Legendre.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_LEGENDRE
@@ -7505,6 +7640,9 @@ save_atom_site_rot_legendre.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_rot_Legendre
     _name.object_id               structure_id
@@ -7539,6 +7677,9 @@ save_ATOM_SITE_ROT_ORTHO
       information about the orthogonalized functions) using the data
       items defined in the categories ATOM_SITE_ROT_FOURIER and
       ATOM_SITE_ROT_FOURIER_PARAM.
+
+      _atom_site_rot_ortho.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_ORTHO
@@ -7727,6 +7868,9 @@ save_atom_site_rot_ortho.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_rot_ortho
     _name.object_id               structure_id
@@ -7768,6 +7912,9 @@ save_ATOM_SITE_ROT_SAWTOOTH
 
       For more information and references see the description of the
       ATOM_SITE_DISPLACE_SAWTOOTH category.
+
+      _atom_site_rot_sawtooth.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_SAWTOOTH
@@ -8038,6 +8185,9 @@ save_atom_site_rot_sawtooth.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_rot_sawtooth
     _name.object_id               structure_id
@@ -8100,6 +8250,9 @@ save_ATOM_SITE_ROT_XHARM
       category would only include the rotational part of the modulation.
       The translational part would appear in a separate list of items
       belonging to the ATOM_SITE_DISPLACE_XHARM category.
+
+      _atom_site_rot_xharm.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_XHARM
@@ -8285,6 +8438,9 @@ save_atom_site_rot_xharm.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_rot_xharm
     _name.object_id               structure_id
@@ -8328,6 +8484,9 @@ save_ATOM_SITE_ROT_ZIGZAG
 
       For more information and references see the description of the
       ATOM_SITE_DISPLACE_SAWTOOTH category.
+
+      _atom_site_rot_zigzag.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_ZIGZAG
@@ -8457,6 +8616,9 @@ save_atom_site_rot_zigzag.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_rot_zigzag
     _name.object_id               structure_id
@@ -8516,6 +8678,9 @@ save_ATOM_SITE_U_FOURIER
       harmonic ADPs in a modulated structure. The (in general complex)
       coefficients of each Fourier component belong to the child
       ATOM_SITE_U_FOURIER_PARAM category and may be listed separately.
+
+      _atom_site_U_Fourier.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_FOURIER
@@ -8676,6 +8841,9 @@ save_atom_site_u_fourier.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_U_Fourier
     _name.object_id               structure_id
@@ -8776,6 +8944,9 @@ save_ATOM_SITE_U_FOURIER_PARAM
 
       Fourier coefficients of the harmonic ADPs must be expressed in
       angstroms squared.
+
+      _atom_site_U_Fourier_param.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             ATOM_SITE_U_FOURIER
     _name.object_id               ATOM_SITE_U_FOURIER_PARAM
@@ -9125,6 +9296,9 @@ save_atom_site_u_fourier_param.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_U_Fourier_param
     _name.object_id               structure_id
@@ -9149,6 +9323,9 @@ save_ATOM_SITE_U_LEGENDRE
       harmonic ADP modulations when the atomic domain of a given atom is
       restricted by a crenel function. See ATOM_SITE_DISPLACE_LEGENDRE
       for more detailed information.
+
+      _atom_site_U_Legendre.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_LEGENDRE
@@ -9353,6 +9530,9 @@ save_atom_site_u_legendre.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_U_Legendre
     _name.object_id               structure_id
@@ -9416,6 +9596,9 @@ save_ATOM_SITE_U_ORTHO
       information about the orthogonalized functions) using the data items
       defined in the categories ATOM_SITE_U_FOURIER and
       ATOM_SITE_U_FOURIER_PARAM.
+
+      _atom_site_U_ortho.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_ORTHO
@@ -9535,6 +9718,9 @@ save_atom_site_u_ortho.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_U_ortho
     _name.object_id               structure_id
@@ -9590,6 +9776,9 @@ save_ATOM_SITE_U_XHARM
       the x-harmonics used to describe the harmonic ADP modulations when
       the atomic domain of a given atom is restricted by a crenel
       function. See ATOM_SITE_DISPLACE_XHARM for more detailed information.
+
+      _atom_site_U_xharm.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_XHARM
@@ -9803,6 +9992,9 @@ save_atom_site_u_xharm.structure_id
     _description.text
 ;
     A code identifying the structure to which this atom site belongs.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             atom_site_U_xharm
     _name.object_id               structure_id

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -25,7 +25,7 @@ data_CIF_MS
     _dictionary.formalism         Modulated
     _dictionary.class             Instance
     _dictionary.version           3.2.5
-    _dictionary.date              2026-06-30
+    _dictionary.date              2026-06-29
     _dictionary.uri               http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance   4.2.0
     _dictionary.licensing_SPDX    CC-BY-4.0
@@ -263,6 +263,7 @@ save_ATOM_SITE_ANHARMONIC_ADP
     loop_
       _category_key.name
          '_atom_site_anharmonic_ADP.atom_site_label'
+         '_atom_site_anharmonic_ADP.structure_id'
          '_atom_site_anharmonic_ADP.tens_elem'
 
     loop_
@@ -658,7 +659,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
        Data items in the ATOM_SITE_ANHARMONIC_ADP_FOURIER category record
@@ -670,7 +671,12 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_FOURIER
-    _category_key.name            '_atom_site_anharmonic_ADP_Fourier.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_anharmonic_ADP_Fourier.id'
+         '_atom_site_anharmonic_ADP_Fourier.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -749,7 +755,8 @@ save_atom_site_anharmonic_adp_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-          The code the that identifies an atom in a loop in which the Fourier
+          The code, along with _atom_site_anharmonic_adp_fourier.structure_id,
+          that identifies an atom in a loop in which the Fourier
           components of the tensors that parameterize its anharmonic ADP
           modulation are listed. This code must match the _atom_site.label of
           the associated coordinate list and conform to the rules described
@@ -932,7 +939,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-02
+    _definition.update            2026-06-03
     _description.text
 ;
           Data items in the ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM category
@@ -965,7 +972,12 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_ANHARMONIC_ADP_FOURIER
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
-    _category_key.name            '_atom_site_anharmonic_ADP_Fourier_param.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_anharmonic_ADP_Fourier_param.id'
+         '_atom_site_anharmonic_ADP_Fourier_param.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -1296,7 +1308,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ANHARMONIC_ADP_LEGENDRE category record
@@ -1309,7 +1321,11 @@ save_ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
-    _category_key.name            '_atom_site_anharmonic_ADP_legendre.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_anharmonic_ADP_Legendre.id'
+         '_atom_site_anharmonic_ADP_Legendre.structure_id'
 
 save_
 
@@ -1320,7 +1336,8 @@ save_atom_site_anharmonic_adp_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code the identifies an atom in a loop in which the Legendre
+      The code, along with _atom_site_anharmonic_adp_Legendre.structure_id,
+      that identifies an atom in a loop in which the Legendre
       components of the tensors that parameterize its anharmonic ADP
       modulation are listed. This code must match the _atom_site.label of
       the associated coordinate list and conform to the rules described
@@ -1535,7 +1552,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_ORTHO
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ANHARMONIC_ADP_ORTHO category record
@@ -1552,7 +1569,11 @@ save_ATOM_SITE_ANHARMONIC_ADP_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_ORTHO
-    _category_key.name            '_atom_site_anharmonic_ADP_ortho.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_anharmonic_ADP_ortho.id'
+         '_atom_site_anharmonic_ADP_ortho.structure_id'
 
 save_
 
@@ -1783,7 +1804,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_XHARM
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ANHARMONIC_ADP_XHARM category record
@@ -1796,7 +1817,11 @@ save_ATOM_SITE_ANHARMONIC_ADP_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_XHARM
-    _category_key.name            '_atom_site_anharmonic_ADP_xharm.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_anharmonic_ADP_xharm.id'
+         '_atom_site_anharmonic_ADP_xharm.structure_id'
 
 save_
 
@@ -1807,7 +1832,8 @@ save_atom_site_anharmonic_adp_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code the identifies an atom in a loop in which the x-harmonics
+      The code, along with _atom_site_anharmonic_adp_xharm.structure_id,
+      that identifies an atom in a loop in which the x-harmonics
       components of the tensors that parameterize its anharmonic ADP
       modulation are listed. This code must match the _atom_site.label of
       the associated coordinate list and conform to the rules described
@@ -2019,7 +2045,7 @@ save_ATOM_SITE_DISPLACE_FOURIER
     _definition.id                ATOM_SITE_DISPLACE_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_FOURIER category record
@@ -2037,7 +2063,12 @@ save_ATOM_SITE_DISPLACE_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_FOURIER
-    _category_key.name            '_atom_site_displace_Fourier.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_displace_Fourier.id'
+         '_atom_site_displace_Fourier.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -2130,7 +2161,8 @@ save_atom_site_displace_fourier.atom_site_label
       Modulated parameters are the atom positions (displacive
       modulation), the atomic occupation (occupational modulation)
       and the isotropic or anisotropic (harmonic or anharmonic) ADPs.
-      _atom_site_displace_Fourier.atom_site_label is the code that
+      _atom_site_displace_Fourier.atom_site_label, along with
+      _atom_site_displace_Fourier.structure_id, is the code that
       identifies an atom or rigid group in a loop in which the Fourier
       components of its displacive modulation are listed. In the case
       of a rigid group, this list would only include the translational
@@ -2295,7 +2327,7 @@ save_ATOM_SITE_DISPLACE_FOURIER_PARAM
     _definition.id                ATOM_SITE_DISPLACE_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-07-31
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_FOURIER_PARAM category
@@ -2340,7 +2372,12 @@ save_ATOM_SITE_DISPLACE_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_DISPLACE_FOURIER
     _name.object_id               ATOM_SITE_DISPLACE_FOURIER_PARAM
-    _category_key.name            '_atom_site_displace_Fourier_param.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_displace_Fourier_param.id'
+         '_atom_site_displace_Fourier_param.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -2682,7 +2719,7 @@ save_ATOM_SITE_DISPLACE_LEGENDRE
     _definition.id                ATOM_SITE_DISPLACE_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-06-04
+    _definition.update            2026-06-03
     _description.text
 ;
       The set of harmonic functions used in the Fourier series
@@ -2746,7 +2783,12 @@ save_ATOM_SITE_DISPLACE_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_LEGENDRE
-    _category_key.name            '_atom_site_displace_Legendre.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_displace_Legendre.id'
+         '_atom_site_displace_Legendre.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -2827,7 +2869,8 @@ save_atom_site_displace_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_displace_Legendre.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the Legendre components of its displacive modulation are listed.
       This code must match the _atom_site.label of the associated
       coordinate list and conform to the rules described in _atom_site.label.
@@ -3014,7 +3057,7 @@ save_ATOM_SITE_DISPLACE_ORTHO
     _definition.id                ATOM_SITE_DISPLACE_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-15
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_ORTHO category record
@@ -3045,7 +3088,12 @@ save_ATOM_SITE_DISPLACE_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_ORTHO
-    _category_key.name            '_atom_site_displace_ortho.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_displace_ortho.id'
+         '_atom_site_displace_ortho.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -3163,7 +3211,8 @@ save_atom_site_displace_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_displace_ortho.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the ortho components of its displacive modulation are listed.
       This code must match the _atom_site.label of the associated
       coordinate list andconform to the rules described in _atom_site.label.
@@ -3407,7 +3456,11 @@ save_ATOM_SITE_DISPLACE_SAWTOOTH
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_SAWTOOTH
-    _category_key.name            '_atom_site_displace_sawtooth.atom_site_label'
+
+    loop_
+      _category_key.name
+         '_atom_site_displace_sawtooth.atom_site_label'
+         '_atom_site_displace_sawtooth.structure_id'
 
     loop_
       _description_example.case
@@ -3493,7 +3546,8 @@ save_atom_site_displace_sawtooth.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_displace_sawtooth.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the sawtooth function that describes its displacive modulation is
       being defined. This code must match the _atom_site.label of the
       associated coordinate list and conform to the rules described in
@@ -3799,7 +3853,7 @@ save_ATOM_SITE_DISPLACE_XHARM
     _definition.id                ATOM_SITE_DISPLACE_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       The set of harmonic functions used in the Fourier series
@@ -3861,7 +3915,12 @@ save_ATOM_SITE_DISPLACE_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_XHARM
-    _category_key.name            '_atom_site_displace_xharm.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_displace_xharm.id'
+         '_atom_site_displace_xharm.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -3947,7 +4006,8 @@ save_atom_site_displace_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-       The code that identifies an atom or rigid group in a loop in which the
+       The code, along with _atom_site_displace_xharm.structure_id, that
+       identifies an atom or rigid group in a loop in which the
        x-harmonics components of its displacive modulation are listed. In
        the case of a rigid group, this list would only include the
        translational part of its displacive modulation. The rotational part
@@ -4180,7 +4240,12 @@ save_ATOM_SITE_DISPLACE_ZIGZAG
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_ZIGZAG
-    _category_key.name            '_atom_site_displace_zigzag.atom_site_label'
+
+    loop_
+      _category_key.name
+         '_atom_site_displace_zigzag.atom_site_label'
+         '_atom_site_displace_zigzag.structure_id'
+
     _description_example.case
 ;
     #\#CIF_2.0
@@ -4235,7 +4300,8 @@ save_atom_site_displace_zigzag.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_displace_zigzag.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the zigzag function that describes its displacive modulation is
       being defined. This code must match the _atom_site.label of the
       associated coordinate list and conform to the rules described in
@@ -4400,7 +4466,7 @@ save_ATOM_SITE_FOURIER_WAVE_VECTOR
     _definition.id                ATOM_SITE_FOURIER_WAVE_VECTOR
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-30
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_FOURIER_WAVE_VECTOR category record
@@ -5166,7 +5232,12 @@ save_ATOM_SITE_OCC_CRENEL
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_CRENEL
-    _category_key.name            '_atom_site_occ_crenel.atom_site_label'
+
+    loop_
+      _category_key.name
+         '_atom_site_occ_crenel.atom_site_label'
+         '_atom_site_occ_crenel.structure_id'
+
     _description_example.case
 ;
     #\#CIF_2.0
@@ -5229,7 +5300,8 @@ save_atom_site_occ_crenel.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in
+      The code, along with _atom_site_occ_crenel.structure_id, that
+      identifies an atom or rigid group in a loop in
       which the parameters of the crenel function that describes its
       occupational modulation are listed. This code must match
       the _atom_site.label of the associated coordinate list and
@@ -5387,7 +5459,7 @@ save_ATOM_SITE_OCC_FOURIER
     _definition.id                ATOM_SITE_OCC_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_OCC_FOURIER category record details
@@ -5401,7 +5473,12 @@ save_ATOM_SITE_OCC_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_FOURIER
-    _category_key.name            '_atom_site_occ_Fourier.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_occ_Fourier.id'
+         '_atom_site_occ_Fourier.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -5485,7 +5562,8 @@ save_atom_site_occ_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom in a loop in which the Fourier
+      The code, along with _atom_site_occ_fourier.structure_id, that
+      identifies an atom in a loop in which the Fourier
       components of its occupational modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -5570,7 +5648,7 @@ save_ATOM_SITE_OCC_FOURIER_PARAM
     _definition.id                ATOM_SITE_OCC_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-07-31
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_OCC_FOURIER_PARAM category record
@@ -5602,7 +5680,12 @@ save_ATOM_SITE_OCC_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_OCC_FOURIER
     _name.object_id               ATOM_SITE_OCC_FOURIER_PARAM
-    _category_key.name            '_atom_site_occ_Fourier_param.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_occ_Fourier_param.id'
+         '_atom_site_occ_Fourier_param.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -5920,7 +6003,7 @@ save_ATOM_SITE_OCC_LEGENDRE
     _definition.id                ATOM_SITE_OCC_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_OCC_LEGENDRE category record
@@ -5934,7 +6017,11 @@ save_ATOM_SITE_OCC_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_LEGENDRE
-    _category_key.name            '_atom_site_occ_Legendre.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_occ_Legendre.id'
+         '_atom_site_occ_Legendre.structure_id'
 
 save_
 
@@ -5945,7 +6032,8 @@ save_atom_site_occ_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_occ_legendre.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the Legendre components of its occupational modulation are listed.
       This code must match the _atom_site.label of the associated coordinate
       list and conform to the rules described in _atom_site.label.
@@ -6061,7 +6149,7 @@ save_ATOM_SITE_OCC_ORTHO
     _definition.id                ATOM_SITE_OCC_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
 
@@ -6084,7 +6172,11 @@ save_ATOM_SITE_OCC_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_ORTHO
-    _category_key.name            '_atom_site_occ_ortho.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_occ_ortho.id'
+         '_atom_site_occ_ortho.structure_id'
 
 save_
 
@@ -6096,7 +6188,8 @@ save_atom_site_occ_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_occ_ortho.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the ortho components of its occupational modulation are listed.
       This code must match the _atom_site.label of the associated coordinate
       list and conform to the rules described in _atom_site.label.
@@ -6228,7 +6321,11 @@ save_ATOM_SITE_OCC_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_XHARM
-    _category_key.name            '_atom_site_occ_xharm.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_occ_xharm.id'
+         '_atom_site_occ_xharm.structure_id'
 
 save_
 
@@ -6239,7 +6336,8 @@ save_atom_site_occ_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_occ_xharm.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the x-harmonic components of its occupational modulation are listed.
       This code must match the _atom_site.label of the associated coordinate
       list and conform to the rules described in _atom_site.label.
@@ -6355,7 +6453,7 @@ save_ATOM_SITE_PHASON
     _definition.id                ATOM_SITE_PHASON
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_PHASON category record details
@@ -6369,7 +6467,11 @@ save_ATOM_SITE_PHASON
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_PHASON
-    _category_key.name            '_atom_site_phason.atom_site_label'
+
+    loop_
+      _category_key.name
+         '_atom_site_phason.atom_site_label'
+         '_atom_site_phason.structure_id'
 
 save_
 
@@ -6380,7 +6482,8 @@ save_atom_site_phason.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in
+      The code, along with _atom_site_phason.structure_id, that
+      identifies an atom or rigid group in a loop in
       which the phason coefficients are listed. Although this kind of
       correction is intended to be overall, some refinement programs
       (for example, JANA) allow an independent phason correction
@@ -6497,7 +6600,7 @@ save_ATOM_SITE_ROT_FOURIER
     _definition.id                ATOM_SITE_ROT_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-06-04
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_FOURIER category record details
@@ -6514,7 +6617,12 @@ save_ATOM_SITE_ROT_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_FOURIER
-    _category_key.name            '_atom_site_rot_Fourier.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_rot_Fourier.id'
+         '_atom_site_rot_Fourier.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -6699,7 +6807,8 @@ save_atom_site_rot_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies a rigid group in a loop in which the Fourier
+      The code, along with _atom_site_rot_fourier.structure_id, that
+      identifies a rigid group in a loop in which the Fourier
       components of the rotational part of its displacive modulation
       are listed. The translational part (if any) would appear in a
       separate list (see _atom_site_displace_Fourier.atom_site_label).
@@ -6853,7 +6962,7 @@ save_ATOM_SITE_ROT_FOURIER_PARAM
     _definition.id                ATOM_SITE_ROT_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-06-04
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_FOURIER_PARAM category record
@@ -6897,7 +7006,12 @@ save_ATOM_SITE_ROT_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_ROT_FOURIER
     _name.object_id               ATOM_SITE_ROT_FOURIER_PARAM
-    _category_key.name            '_atom_site_rot_Fourier_param.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_rot_Fourier_param.id'
+         '_atom_site_rot_Fourier_param.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -7356,7 +7470,7 @@ save_ATOM_SITE_ROT_LEGENDRE
     _definition.id                ATOM_SITE_ROT_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_LEGENDRE category record
@@ -7372,7 +7486,11 @@ save_ATOM_SITE_ROT_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_LEGENDRE
-    _category_key.name            '_atom_site_rot_Legendre.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_rot_Legendre.id'
+         '_atom_site_rot_Legendre.structure_id'
 
 save_
 
@@ -7382,7 +7500,8 @@ save_atom_site_rot_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_rot_legendre.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the Legendre components of its displacive modulation are listed.
       In the case of a rigid group, this list would only include the
       rotational part of its displacive modulation. The translational
@@ -7568,7 +7687,7 @@ save_ATOM_SITE_ROT_ORTHO
     _definition.id                ATOM_SITE_ROT_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_ORTHO category record
@@ -7592,7 +7711,11 @@ save_ATOM_SITE_ROT_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_ORTHO
-    _category_key.name            '_atom_site_rot_ortho.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_rot_ortho.id'
+         '_atom_site_rot_ortho.structure_id'
 
 save_
 
@@ -7602,7 +7725,8 @@ save_atom_site_rot_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_rot_ortho.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the ortho components of its displacive modulation are listed.
       In the case of a rigid group, this list would only include the
       rotational part of its displacive modulation. The translational
@@ -7791,7 +7915,7 @@ save_ATOM_SITE_ROT_SAWTOOTH
     _definition.id                ATOM_SITE_ROT_SAWTOOTH
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-06-04
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_SAWTOOTH category record
@@ -7822,7 +7946,11 @@ save_ATOM_SITE_ROT_SAWTOOTH
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_SAWTOOTH
-    _category_key.name            '_atom_site_rot_sawtooth.atom_site_label'
+
+    loop_
+      _category_key.name
+         '_atom_site_rot_sawtooth.atom_site_label'
+         '_atom_site_rot_sawtooth.structure_id'
 
 save_
 
@@ -7833,7 +7961,8 @@ save_atom_site_rot_sawtooth.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies a rigid group in a loop in which a sawtooth
+      The code, along with _atom_site_rot_sawtooth.structure_id, that
+      identifies a rigid group in a loop in which a sawtooth
       function that describes the rotational part of its displacive
       modulation is being defined. This code must match the _atom_site.label
       of the associated coordinate list and conform to the rules described
@@ -8139,7 +8268,7 @@ save_ATOM_SITE_ROT_XHARM
     _definition.id                ATOM_SITE_ROT_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_XHARM category record
@@ -8155,7 +8284,11 @@ save_ATOM_SITE_ROT_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_XHARM
-    _category_key.name            '_atom_site_rot_xharm.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_rot_xharm.id'
+         '_atom_site_rot_xharm.structure_id'
 
 save_
 
@@ -8165,7 +8298,8 @@ save_atom_site_rot_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_rot_xharm.structure_id, that
+      identifies an atom or rigid group in a loop in which
       the x-harmonics components of its displacive modulation are listed.
       In the case of a rigid group, this list would only include the
       rotational part of its displacive modulation. The translational
@@ -8351,7 +8485,7 @@ save_ATOM_SITE_ROT_ZIGZAG
     _definition.id                ATOM_SITE_ROT_ZIGZAG
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2025-06-04
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_ZIGZAG category record
@@ -8384,7 +8518,11 @@ save_ATOM_SITE_ROT_ZIGZAG
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_ZIGZAG
-    _category_key.name            '_atom_site_rot_zigzag.atom_site_label'
+
+    loop_
+      _category_key.name
+         '_atom_site_rot_zigzag.atom_site_label'
+         '_atom_site_rot_zigzag.structure_id'
 
 save_
 
@@ -8394,7 +8532,8 @@ save_atom_site_rot_zigzag.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom or rigid group in a loop in which
+      The code, along with _atom_site_rot_zigzag.structure_id, that
+      identifies an atom or rigid group in a loop in which
       a zigzag function that describes the rotational part of its displacive
       modulation is being defined. This code must match the _atom_site.label
       of the associated coordinate list and conform to the rules described
@@ -8559,7 +8698,7 @@ save_ATOM_SITE_U_FOURIER
     _definition.id                ATOM_SITE_U_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_U_FOURIER category record details
@@ -8573,7 +8712,12 @@ save_ATOM_SITE_U_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_FOURIER
-    _category_key.name            '_atom_site_U_Fourier.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_U_Fourier.id'
+         '_atom_site_U_Fourier.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -8683,7 +8827,8 @@ save_atom_site_u_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom in a loop in which the Fourier
+      The code, along with _atom_site_u_fourier.structure_id, that
+      identifies an atom in a loop in which the Fourier
       components of its harmonic ADP modulation are listed.  This code
       must match the _atom_site.label of the associated coordinate list
       and conform to the rules described in _atom_site.label.
@@ -8798,7 +8943,7 @@ save_ATOM_SITE_U_FOURIER_PARAM
     _definition.id                ATOM_SITE_U_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-07-31
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_U_FOURIER_PARAM category record details
@@ -8833,7 +8978,12 @@ save_ATOM_SITE_U_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_U_FOURIER
     _name.object_id               ATOM_SITE_U_FOURIER_PARAM
-    _category_key.name            '_atom_site_U_Fourier_param.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_U_Fourier_param.id'
+         '_atom_site_U_Fourier_param.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -9193,7 +9343,7 @@ save_ATOM_SITE_U_LEGENDRE
     _definition.id                ATOM_SITE_U_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_U_LEGENDRE category record
@@ -9207,7 +9357,12 @@ save_ATOM_SITE_U_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_LEGENDRE
-    _category_key.name            '_atom_site_u_Legendre.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_U_Legendre.id'
+         '_atom_site_U_Legendre.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -9304,7 +9459,8 @@ save_atom_site_u_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom in a loop in which the Legendre
+      The code, along with _atom_site_u_legendre.structure_id, that
+      identifies an atom in a loop in which the Legendre
       components of its harmonic ADP modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -9452,7 +9608,7 @@ save_ATOM_SITE_U_ORTHO
     _definition.id                ATOM_SITE_U_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_U_ORTHO category record
@@ -9474,7 +9630,11 @@ save_ATOM_SITE_U_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_ORTHO
-    _category_key.name            '_atom_site_U_ortho.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_U_ortho.id'
+         '_atom_site_U_ortho.structure_id'
 
 save_
 
@@ -9486,7 +9646,8 @@ save_atom_site_u_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom in a loop in which the ortho
+      The code, along with _atom_site_u_ortho.structure_id, that
+      identifies an atom in a loop in which the ortho
       components of its harmonic ADP modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -9636,7 +9797,7 @@ save_ATOM_SITE_U_XHARM
     _definition.id                ATOM_SITE_U_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-03
     _description.text
 ;
       Data items in the ATOM_SITE_U_XHARM category record details about
@@ -9649,7 +9810,12 @@ save_ATOM_SITE_U_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_XHARM
-    _category_key.name            '_atom_site_U_xharm.id'
+
+    loop_
+      _category_key.name
+         '_atom_site_U_xharm.id'
+         '_atom_site_U_xharm.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
@@ -9756,7 +9922,8 @@ save_atom_site_u_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code that identifies an atom in a loop in which the x-harmonic
+      The code, along with _atom_site_u_xharm.structure_id, that
+      identifies an atom in a loop in which the x-harmonic
       components of its harmonic ADP modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -10085,7 +10252,6 @@ save_ATOM_SITES_MODULATION
     _definition.id                ATOM_SITES_MODULATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-06-04
     _description.text
 ;
       Data items in the ATOM_SITES_MODULATION category record details
@@ -10093,6 +10259,7 @@ save_ATOM_SITES_MODULATION
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_MODULATION
+    _category_key.name            '_atom_sites_modulation.structure_id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -10462,6 +10629,15 @@ save_atom_sites_modulation.global_phase_t_9
 
 save_
 
+save_atom_sites_modulation.structure_id
+
+    _definition.update            2026-06-15
+    _description.text
+;
+    A code identifying the crystallographic structure associated with the
+    atom sites.
+;
+    _name.category_id             atom_sites_modulation
 save_ATOM_SITES_ORTHO
 
     _definition.id                ATOM_SITES_ORTHO
@@ -10499,6 +10675,10 @@ save_ATOM_SITES_ORTHO
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_ORTHO
     _category_key.name            '_atom_sites_ortho.func_id'
+      _category_key.name
+         '_atom_sites_ortho.func_id'
+         '_atom_sites_ortho.structure_id'
+
     _description_example.case
 ;
     #\#CIF_2.0
@@ -10627,6 +10807,13 @@ save_atom_sites_ortho.func_id
 
 save_
 
+    _definition.update            2026-06-15
+    _description.text
+;
+    A code identifying the crystallographic structure associated with the
+    atom sites.
+;
+    _name.category_id             atom_sites_ortho
 save_atom_sites_ortho.wave_vector_seq_id_list
 
     _definition.id                '_atom_sites_ortho.wave_vector_seq_id_list'
@@ -19482,7 +19669,6 @@ save_
         2024-12-12
         Technical fixes (JRH)
 ;
-         3.2.5                    2026-06-30
 ;
         _SPECIAL_FUNC categories, replaced by:
         _DISPLACE_SAWTOOTH
@@ -19561,7 +19747,44 @@ save_
         Changed the _category_key.name  of DIFFRN_REFLN and REFLN to
         _diffrn_refln.id and _refln.id, respectively.
 
+        2026-06-03
+        ATOM_SITE_DISPLACE_SAWTOOTH
+        ATOM_SITE_DISPLACE_ZIGZAG
+        ATOM_SITE_OCC_CRENEL
+        ATOM_SITE_PHASON
+        ATOM_SITE_ROT_SAWTOOTH
+        ATOM_SITE_ROT_ZIGZAG
+
+        ATOM_SITE_ANHARMONIC_ADP_FOURIER
+        ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
+        ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
+        ATOM_SITE_ANHARMONIC_ADP_XHARM
+        ATOM_SITE_DISPLACE_FOURIER
+        ATOM_SITE_DISPLACE_FOURIER_PARAM
+        ATOM_SITE_DISPLACE_LEGENDRE
+        ATOM_SITE_DISPLACE_ORTHO
+        ATOM_SITE_DISPLACE_XHARM
+        ATOM_SITE_OCC_FOURIER
+        ATOM_SITE_OCC_FOURIER_PARAM
+        ATOM_SITE_OCC_LEGENDRE
+        ATOM_SITE_OCC_ORTHO
+        ATOM_SITE_OCC_XHARM
+        ATOM_SITE_ROT_FOURIER
+        ATOM_SITE_ROT_FOURIER_PARAM
+        ATOM_SITE_ROT_LEGENDRE
+        ATOM_SITE_ROT_ORTHO
+        ATOM_SITE_ROT_XHARM
+        ATOM_SITE_U_FOURIER
+        ATOM_SITE_U_FOURIER_PARAM
+        ATOM_SITE_U_LEGENDRE
+        ATOM_SITE_U_ORTHO
+        ATOM_SITE_U_XHARM
+
         2026-06-15
+        2026-06-15
+        Added linked key *.structure_id data names to ATOM_SITES_AXES,
+        ATOM_SITES_MODULATION, and ATOM_SITES_ORTHO.
+
         Added key _superspace_group.id and linked key
         _superspace_group_symop.superspace_group_id
 


### PR DESCRIPTION
close #43, see also #41

`ATOM_SITE` gained an extra key in `multi_block_core`. This PR adds a linked structure dataname to each category referencing `ATOM_SITE`.