### PR TITLE
Explicitly deprecate the ATOM_SITES_DISPLACE_FOURIER category

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -25,7 +25,7 @@ data_CIF_MS
     _dictionary.formalism         Modulated
     _dictionary.class             Instance
     _dictionary.version           3.2.5
-    _dictionary.date              2026-05-02
+    _dictionary.date              2026-06-15
     _dictionary.uri               http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance   4.1.0
     _dictionary.licensing_SPDX    CC-BY-4.0
@@ -9228,7 +9228,9 @@ save_ATOM_SITES_DISPLACE_FOURIER
     _definition.id                ATOM_SITES_DISPLACE_FOURIER
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2024-08-09
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the ATOM_SITES_DISPLACE_FOURIER category record
@@ -18590,7 +18592,7 @@ save_
         2024-12-12
         Technical fixes (JRH)
 ;
-         3.2.5                    2026-05-02
+         3.2.5                    2026-06-15
 ;
         _SPECIAL_FUNC categories, replaced by:
         _DISPLACE_SAWTOOTH
@@ -18668,4 +18670,8 @@ save_
 
         Changed the _category_key.name  of DIFFRN_REFLN and REFLN to
         _diffrn_refln.id and _refln.id, respectively.
+
+        2026-06-15
+
+        Explicitly deprecated the ATOM_SITES_DISPLACE_FOURIER category.
 ;


### PR DESCRIPTION
All data items that belong to this category are already deprecated.