### PR TITLE
add GEOM_*.model_id as linked key

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -15245,7 +15245,7 @@ save_GEOM_ANGLE
     _definition.id                GEOM_ANGLE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the GEOM_ANGLE category record
@@ -15268,6 +15268,7 @@ save_GEOM_ANGLE
          '_geom_angle.atom_site_label_1'
          '_geom_angle.atom_site_label_2'
          '_geom_angle.atom_site_label_3'
+         '_geom_angle.model_id'
          '_geom_angle.site_ssg_symmetry_1'
          '_geom_angle.site_ssg_symmetry_2'
          '_geom_angle.site_ssg_symmetry_3'
@@ -15582,7 +15583,7 @@ save_GEOM_BOND
     _definition.id                GEOM_BOND
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the GEOM_BOND category record
@@ -15600,6 +15601,7 @@ save_GEOM_BOND
       _category_key.name
          '_geom_bond.atom_site_label_1'
          '_geom_bond.atom_site_label_2'
+         '_geom_angle.model_id'
          '_geom_bond.site_ssg_symmetry_1'
          '_geom_bond.site_ssg_symmetry_2'
 
@@ -15787,7 +15789,7 @@ save_GEOM_CONTACT
     _definition.id                GEOM_CONTACT
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
       The CATEGORY of data items used to specify the interatomic
@@ -15803,6 +15805,7 @@ save_GEOM_CONTACT
       _category_key.name
          '_geom_contact.atom_site_label_1'
          '_geom_contact.atom_site_label_2'
+         '_geom_angle.model_id'
          '_geom_contact.site_ssg_symmetry_1'
          '_geom_contact.site_ssg_symmetry_2'
 
@@ -15951,7 +15954,7 @@ save_GEOM_HBOND
     _definition.id                GEOM_HBOND
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
      The CATEGORY of data items used to specify the hydrogen bond
@@ -15969,6 +15972,7 @@ save_GEOM_HBOND
          '_geom_hbond.atom_site_label_D'
          '_geom_hbond.atom_site_label_H'
          '_geom_hbond.atom_site_label_A'
+         '_geom_angle.model_id'
          '_geom_hbond.site_ssg_symmetry_D'
          '_geom_hbond.site_ssg_symmetry_H'
          '_geom_hbond.site_ssg_symmetry_A'
@@ -16487,7 +16491,7 @@ save_GEOM_TORSION
     _definition.id                GEOM_TORSION
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
      The CATEGORY of data items used to specify the torsion angles in the
@@ -16506,6 +16510,7 @@ save_GEOM_TORSION
          '_geom_torsion.atom_site_label_2'
          '_geom_torsion.atom_site_label_3'
          '_geom_torsion.atom_site_label_4'
+         '_geom_angle.model_id'
          '_geom_torsion.site_ssg_symmetry_1'
          '_geom_torsion.site_ssg_symmetry_2'
          '_geom_torsion.site_ssg_symmetry_3'

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -15261,6 +15261,9 @@ save_GEOM_ANGLE
       in the way that they are calculated, even if the
       calculation method is not explicit in either this
       dictionary or the core.
+
+      _geom_angle.model_id may be omitted if only one _model.id
+      is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               GEOM_ANGLE
@@ -15595,6 +15598,9 @@ save_GEOM_BOND
       higher-dimensional superspace form and therefore
       redefines many datanames to reflect the changed
       method of distance calculation.
+
+      _geom_bond.model_id may be omitted if only one
+      _model.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               GEOM_BOND
@@ -15799,6 +15805,9 @@ save_GEOM_CONTACT
       the symmetry-operation code used in bond listings to the
       higher-dimensional superspace form and therefore redefines many
       datanames to reflect the changed method of distance calculation.
+
+      _geom_contact.model_id may be omitted if only one _model.id is
+      present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               GEOM_CONTACT
@@ -15965,6 +15974,9 @@ save_GEOM_HBOND
      to the higher-dimensional superspace form and therefore redefines many
      datanames to reflect the changed method of distance and angle
      calculation.
+
+     _geom_hbond.model_id may be omitted if only one _model.id is present
+     in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               GEOM_HBOND
@@ -16502,6 +16514,9 @@ save_GEOM_TORSION
      higher-dimensional superspace form and therefore redefines many
      datanames to reflect the changed method of distance and angle
      calculation.
+
+     _geom_torsion.model_id may be omitted if only one _model.id is
+     present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               GEOM_TORSION

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -15603,7 +15603,7 @@ save_GEOM_BOND
       _category_key.name
          '_geom_bond.atom_site_label_1'
          '_geom_bond.atom_site_label_2'
-         '_geom_angle.model_id'
+         '_geom_bond.model_id'
          '_geom_bond.site_ssg_symmetry_1'
          '_geom_bond.site_ssg_symmetry_2'
 
@@ -15807,7 +15807,7 @@ save_GEOM_CONTACT
       _category_key.name
          '_geom_contact.atom_site_label_1'
          '_geom_contact.atom_site_label_2'
-         '_geom_angle.model_id'
+         '_geom_contact.model_id'
          '_geom_contact.site_ssg_symmetry_1'
          '_geom_contact.site_ssg_symmetry_2'
 
@@ -15974,7 +15974,7 @@ save_GEOM_HBOND
          '_geom_hbond.atom_site_label_D'
          '_geom_hbond.atom_site_label_H'
          '_geom_hbond.atom_site_label_A'
-         '_geom_angle.model_id'
+         '_geom_hbond.model_id'
          '_geom_hbond.site_ssg_symmetry_D'
          '_geom_hbond.site_ssg_symmetry_H'
          '_geom_hbond.site_ssg_symmetry_A'
@@ -16512,7 +16512,7 @@ save_GEOM_TORSION
          '_geom_torsion.atom_site_label_2'
          '_geom_torsion.atom_site_label_3'
          '_geom_torsion.atom_site_label_4'
-         '_geom_angle.model_id'
+         '_geom_torsion.model_id'
          '_geom_torsion.site_ssg_symmetry_1'
          '_geom_torsion.site_ssg_symmetry_2'
          '_geom_torsion.site_ssg_symmetry_3'

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -25,7 +25,7 @@ data_CIF_MS
     _dictionary.formalism         Modulated
     _dictionary.class             Instance
     _dictionary.version           3.2.5
-    _dictionary.date              2026-05-02
+    _dictionary.date              2026-06-15
     _dictionary.uri               http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance   4.1.0
     _dictionary.licensing_SPDX    CC-BY-4.0
@@ -18595,7 +18595,7 @@ save_
         2024-12-12
         Technical fixes (JRH)
 ;
-         3.2.5                    2026-05-02
+         3.2.5                    2026-06-15
 ;
         _SPECIAL_FUNC categories, replaced by:
         _DISPLACE_SAWTOOTH
@@ -18673,4 +18673,7 @@ save_
 
         Changed the _category_key.name  of DIFFRN_REFLN and REFLN to
         _diffrn_refln.id and _refln.id, respectively.
+
+        Added _geom_*.model_id as linked key data name to GEOM_ANGLE, BOND,
+        CONTACT, HBOND, and TORSION, mimicking CIF_MULTI.
 ;


### PR DESCRIPTION
will close #48 

As given in `cif_multi`, the `GEOM_*` categories have `_model.id` as a linked (composite) key dataname.

Now, too, does `cif_ms`.

The definitions of `_geom_*.model_id` are delegated to `cif_multi`, but the setting it as a key name is done here, as `cif_multi` can't override definitions in `cif_ms`.