### PR TITLE
Added atom_sites_*  structure id key

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -71,8 +71,8 @@ save_ATOM_SITE
     used in crystallographic structure studies.  Items in this
     dictionary enhance those in cif_core.cif to cover modulated
     structures.
-    
-    _atom_site.structure_id may be omitted if only one _structure.id 
+
+    _atom_site.structure_id may be omitted if only one _structure.id
     is present in the same data block.
 ;
     _name.category_id             ATOM
@@ -9113,8 +9113,8 @@ save_ATOM_SITES_AXES
       displacements and rotations of atoms and rigid groups. Details
       for individual atom sites are described by data items in
       the ATOM_SITE_DISPLACE_ and ATOM_SITE_ROT_ categories.
-      
-      _atom_sites_axes.structure_id may be omitted if only one 
+
+      _atom_sites_axes.structure_id may be omitted if only one
       _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
@@ -9216,8 +9216,8 @@ save_atom_sites_axes.structure_id
 ;
     A code identifying the crystallographic structure associated with the
     atom sites.
-    
-    This data name may be omitted if only one _structure.id is present in 
+
+    This data name may be omitted if only one _structure.id is present in
     the same data block.
 ;
     _name.category_id             atom_sites_axes
@@ -9322,8 +9322,8 @@ save_ATOM_SITES_MODULATION
 ;
       Data items in the ATOM_SITES_MODULATION category record details
       common to the modulation of atom sites in a modulated structure.
-      
-      _atom_sites_modulation.structure_id may be omitted if only one 
+
+      _atom_sites_modulation.structure_id may be omitted if only one
       _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
@@ -9706,8 +9706,8 @@ save_atom_sites_modulation.structure_id
 ;
     A code identifying the crystallographic structure associated with the
     atom sites.
-    
-    This data name may be omitted if only one _structure.id is present 
+
+    This data name may be omitted if only one _structure.id is present
     in the same data block.
 ;
     _name.category_id             atom_sites_modulation
@@ -9737,8 +9737,8 @@ save_ATOM_SITES_ORTHO
       The functions are constructed selecting Fourier harmonics
       until a desired degree of orthogonality and completeness is
       reached (see _atom_site_occ_crenel.ortho_eps).
-      
-      _atom_sites_ortho.structure_id may be omitted if only one 
+
+      _atom_sites_ortho.structure_id may be omitted if only one
       _structure.id is present in the same data block.
 
       References: Petricek, V., Van Der Lee & Evain, M. (1995).
@@ -9901,8 +9901,8 @@ save_atom_sites_ortho.structure_id
 ;
     A code identifying the crystallographic structure associated with the
     atom sites.
-    
-    This data name may be omitted if only one _structure.id is present 
+
+    This data name may be omitted if only one _structure.id is present
     in the same data block.
 ;
     _name.category_id             atom_sites_ortho

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -9133,7 +9133,7 @@ save_ATOM_SITES_AXES
     _definition.id                ATOM_SITES_AXES
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the ATOM_SITES_AXES category record
@@ -9147,12 +9147,19 @@ save_ATOM_SITES_AXES
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_AXES
-    _category_key.name            '_atom_sites_axes.matrix_seq_id'
+
+    loop_
+      _category_key.name
+         '_atom_sites_axes.matrix_seq_id'
+         '_atom_sites_axes.structure_id'
+
     _description_example.case
 ;
         #\#CIF_2.0
 
         # - - - - data truncated for brevity - - - -
+
+        _structure.id   "4,4'-Dichlorobiphenyl Sulfone"
 
         loop_
          _atom_sites_axes.matrix_seq_id

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -71,6 +71,9 @@ save_ATOM_SITE
     used in crystallographic structure studies.  Items in this
     dictionary enhance those in cif_core.cif to cover modulated
     structures.
+    
+    _atom_site.structure_id may be omitted if only one _structure.id 
+    is present in the same data block.
 ;
     _name.category_id             ATOM
     _name.object_id               ATOM_SITE
@@ -9110,6 +9113,9 @@ save_ATOM_SITES_AXES
       displacements and rotations of atoms and rigid groups. Details
       for individual atom sites are described by data items in
       the ATOM_SITE_DISPLACE_ and ATOM_SITE_ROT_ categories.
+      
+      _atom_sites_axes.structure_id may be omitted if only one 
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_AXES
@@ -9210,6 +9216,9 @@ save_atom_sites_axes.structure_id
 ;
     A code identifying the crystallographic structure associated with the
     atom sites.
+    
+    This data name may be omitted if only one _structure.id is present in 
+    the same data block.
 ;
     _name.category_id             atom_sites_axes
     _name.object_id               structure_id
@@ -9313,6 +9322,9 @@ save_ATOM_SITES_MODULATION
 ;
       Data items in the ATOM_SITES_MODULATION category record details
       common to the modulation of atom sites in a modulated structure.
+      
+      _atom_sites_modulation.structure_id may be omitted if only one 
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_MODULATION
@@ -9694,6 +9706,9 @@ save_atom_sites_modulation.structure_id
 ;
     A code identifying the crystallographic structure associated with the
     atom sites.
+    
+    This data name may be omitted if only one _structure.id is present 
+    in the same data block.
 ;
     _name.category_id             atom_sites_modulation
     _name.object_id               structure_id
@@ -9722,6 +9737,9 @@ save_ATOM_SITES_ORTHO
       The functions are constructed selecting Fourier harmonics
       until a desired degree of orthogonality and completeness is
       reached (see _atom_site_occ_crenel.ortho_eps).
+      
+      _atom_sites_ortho.structure_id may be omitted if only one 
+      _structure.id is present in the same data block.
 
       References: Petricek, V., Van Der Lee & Evain, M. (1995).
                   Acta Cryst. A51, 529-535. DOI 10.1107/S0108767395000365
@@ -9883,6 +9901,9 @@ save_atom_sites_ortho.structure_id
 ;
     A code identifying the crystallographic structure associated with the
     atom sites.
+    
+    This data name may be omitted if only one _structure.id is present 
+    in the same data block.
 ;
     _name.category_id             atom_sites_ortho
     _name.object_id               structure_id

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -9792,12 +9792,19 @@ save_ATOM_SITES_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_ORTHO
-    _category_key.name            '_atom_sites_ortho.func_id'
+
+    loop_
+      _category_key.name
+         '_atom_sites_ortho.func_id'
+         '_atom_sites_ortho.structure_id'
+
     _description_example.case
 ;
     #\#CIF_2.0
 
     # - - - - data truncated for brevity - - - -
+
+    _structure.id   "\d~1~-CoZn~7.8~"
 
     _cell.modulation_dimension               1
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -9348,7 +9348,7 @@ save_ATOM_SITES_MODULATION
     _definition.id                ATOM_SITES_MODULATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2025-06-04
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the ATOM_SITES_MODULATION category record details
@@ -9359,11 +9359,14 @@ save_ATOM_SITES_MODULATION
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_MODULATION
+    _category_key.name            '_atom_sites_modulation.structure_id'
     _description_example.case
 ;
         #\#CIF_2.0
 
         # - - - - data truncated for brevity - - - -
+
+        _structure.id   Fe(NCS)~2~
 
         _cell.modulation_dimension               1
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -9241,22 +9241,11 @@ save_
 save_atom_sites_axes.structure_id
 
     _definition.id                '_atom_sites_axes.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with the
-    atom sites.
-
-    This data name may be omitted if only one _structure.id is present in
-    the same data block.
-;
     _name.category_id             atom_sites_axes
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 
@@ -9734,22 +9723,11 @@ save_
 save_atom_sites_modulation.structure_id
 
     _definition.id                '_atom_sites_modulation.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with the
-    atom sites.
-
-    This data name may be omitted if only one _structure.id is present
-    in the same data block.
-;
     _name.category_id             atom_sites_modulation
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 
@@ -9931,22 +9909,11 @@ save_
 save_atom_sites_ortho.structure_id
 
     _definition.id                '_atom_sites_ortho.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with the
-    atom sites.
-
-    This data name may be omitted if only one _structure.id is present
-    in the same data block.
-;
     _name.category_id             atom_sites_ortho
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 


### PR DESCRIPTION
Added linked key *.structure_id data names to ATOM_SITES_AXES, ATOM_SITES_MODULATION, and ATOM_SITES_ORTHO.

Did not add to ATOM_SITES_DISPLACE_FOURIER, as it is a deprecated category - see #50 
Did not add to ATOM_SITES_ROT_FOURIER, as it is a deprecated category
Can be added if needed.