### PR TITLE
added keys and links to `cell_wave_vector` and `cell_wave_vectors`

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -260,7 +260,6 @@ save_ATOM_SITE_ANHARMONIC_ADP
     loop_
       _category_key.name
          '_atom_site_anharmonic_ADP.atom_site_label'
-         '_atom_site_anharmonic_ADP.structure_id'
          '_atom_site_anharmonic_ADP.tens_elem'
 
     loop_
@@ -535,24 +534,6 @@ save_atom_site_anharmonic_adp.coeff_su
 
 save_
 
-save_atom_site_anharmonic_adp.structure_id
-
-    _definition.id                '_atom_site_anharmonic_ADP.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_anharmonic_ADP
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_anharmonic_adp.tens_elem
 
     _definition.id                '_atom_site_anharmonic_ADP.tens_elem'
@@ -653,7 +634,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
        Data items in the ATOM_SITE_ANHARMONIC_ADP_FOURIER category record
@@ -662,12 +643,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_FOURIER
-
-    loop_
-      _category_key.name
-         '_atom_site_anharmonic_ADP_Fourier.id'
-         '_atom_site_anharmonic_ADP_Fourier.structure_id'
-
+    _category_key.name            '_atom_site_anharmonic_ADP_Fourier.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -746,8 +722,7 @@ save_atom_site_anharmonic_adp_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-          The code, along with _atom_site_anharmonic_adp_fourier.structure_id,
-          that identifies an atom in a loop in which the Fourier
+          The code the that identifies an atom in a loop in which the Fourier
           components of the tensors that parameterize its anharmonic ADP
           modulation are listed. This code must match the _atom_site.label of
           the associated coordinate list and conform to the rules described
@@ -779,25 +754,6 @@ save_atom_site_anharmonic_adp_fourier.id
     _type.source                  Related
     _type.container               Single
     _type.contents                Code
-
-save_
-
-save_atom_site_anharmonic_adp_fourier.structure_id
-
-    _definition.id
-        '_atom_site_anharmonic_ADP_Fourier.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_anharmonic_ADP_Fourier
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -927,7 +883,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-02
     _description.text
 ;
           Data items in the ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM category
@@ -957,12 +913,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_ANHARMONIC_ADP_FOURIER
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
-
-    loop_
-      _category_key.name
-         '_atom_site_anharmonic_ADP_Fourier_param.id'
-         '_atom_site_anharmonic_ADP_Fourier_param.structure_id'
-
+    _category_key.name            '_atom_site_anharmonic_ADP_Fourier_param.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -1266,31 +1217,12 @@ save_atom_site_anharmonic_adp_fourier_param.sin_su
 
 save_
 
-save_atom_site_anharmonic_adp_fourier_param.structure_id
-
-    _definition.id
-        '_atom_site_anharmonic_ADP_Fourier_param.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_anharmonic_ADP_Fourier_param
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
 
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_ANHARMONIC_ADP_LEGENDRE category record
@@ -1300,11 +1232,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
-
-    loop_
-      _category_key.name
-         '_atom_site_anharmonic_ADP_Legendre.id'
-         '_atom_site_anharmonic_ADP_Legendre.structure_id'
+    _category_key.name            '_atom_site_anharmonic_ADP_legendre.id'
 
 save_
 
@@ -1315,8 +1243,7 @@ save_atom_site_anharmonic_adp_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_anharmonic_adp_Legendre.structure_id,
-      that identifies an atom in a loop in which the Legendre
+      The code the identifies an atom in a loop in which the Legendre
       components of the tensors that parameterize its anharmonic ADP
       modulation are listed. This code must match the _atom_site.label of
       the associated coordinate list and conform to the rules described
@@ -1404,25 +1331,6 @@ save_atom_site_anharmonic_adp_legendre.order
     _type.contents                Integer
     _enumeration.range            0:
     _units.code                   none
-
-save_
-
-save_atom_site_anharmonic_adp_legendre.structure_id
-
-    _definition.id
-        '_atom_site_anharmonic_ADP_Legendre.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_anharmonic_ADP_Legendre
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -1528,7 +1436,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_ORTHO
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_ANHARMONIC_ADP_ORTHO category record
@@ -1542,11 +1450,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_ORTHO
-
-    loop_
-      _category_key.name
-         '_atom_site_anharmonic_ADP_ortho.id'
-         '_atom_site_anharmonic_ADP_ortho.structure_id'
+    _category_key.name            '_atom_site_anharmonic_ADP_ortho.id'
 
 save_
 
@@ -1655,24 +1559,6 @@ save_atom_site_anharmonic_adp_ortho.id
 
 save_
 
-save_atom_site_anharmonic_adp_ortho.structure_id
-
-    _definition.id                '_atom_site_anharmonic_ADP_ortho.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_anharmonic_ADP_ortho
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_anharmonic_adp_ortho.tens_elem
 
     _definition.id                '_atom_site_anharmonic_ADP_ortho.tens_elem'
@@ -1774,7 +1660,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_XHARM
     _definition.id                ATOM_SITE_ANHARMONIC_ADP_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_ANHARMONIC_ADP_XHARM category record
@@ -1784,11 +1670,7 @@ save_ATOM_SITE_ANHARMONIC_ADP_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ANHARMONIC_ADP_XHARM
-
-    loop_
-      _category_key.name
-         '_atom_site_anharmonic_ADP_xharm.id'
-         '_atom_site_anharmonic_ADP_xharm.structure_id'
+    _category_key.name            '_atom_site_anharmonic_ADP_xharm.id'
 
 save_
 
@@ -1799,8 +1681,7 @@ save_atom_site_anharmonic_adp_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_anharmonic_adp_xharm.structure_id,
-      that identifies an atom in a loop in which the x-harmonics
+      The code the identifies an atom in a loop in which the x-harmonics
       components of the tensors that parameterize its anharmonic ADP
       modulation are listed. This code must match the _atom_site.label of
       the associated coordinate list and conform to the rules described
@@ -1888,24 +1769,6 @@ save_atom_site_anharmonic_adp_xharm.order
     _type.contents                Integer
     _enumeration.range            0:
     _units.code                   none
-
-save_
-
-save_atom_site_anharmonic_adp_xharm.structure_id
-
-    _definition.id                '_atom_site_anharmonic_ADP_xharm.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_anharmonic_ADP_xharm
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -2009,7 +1872,7 @@ save_ATOM_SITE_DISPLACE_FOURIER
     _definition.id                ATOM_SITE_DISPLACE_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_FOURIER category record
@@ -2024,12 +1887,7 @@ save_ATOM_SITE_DISPLACE_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_FOURIER
-
-    loop_
-      _category_key.name
-         '_atom_site_displace_Fourier.id'
-         '_atom_site_displace_Fourier.structure_id'
-
+    _category_key.name            '_atom_site_displace_Fourier.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -2122,8 +1980,7 @@ save_atom_site_displace_fourier.atom_site_label
       Modulated parameters are the atom positions (displacive
       modulation), the atomic occupation (occupational modulation)
       and the isotropic or anisotropic (harmonic or anharmonic) ADPs.
-      _atom_site_displace_Fourier.atom_site_label, along with
-      _atom_site_displace_Fourier.structure_id, is the code that
+      _atom_site_displace_Fourier.atom_site_label is the code that
       identifies an atom or rigid group in a loop in which the Fourier
       components of its displacive modulation are listed. In the case
       of a rigid group, this list would only include the translational
@@ -2234,24 +2091,6 @@ save_atom_site_displace_fourier.matrix_seq_id
 
 save_
 
-save_atom_site_displace_fourier.structure_id
-
-    _definition.id                '_atom_site_displace_Fourier.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_displace_Fourier
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_displace_fourier.wave_vector_seq_id
 
     _definition.id
@@ -2285,7 +2124,7 @@ save_ATOM_SITE_DISPLACE_FOURIER_PARAM
     _definition.id                ATOM_SITE_DISPLACE_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-07-31
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_FOURIER_PARAM category
@@ -2327,12 +2166,7 @@ save_ATOM_SITE_DISPLACE_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_DISPLACE_FOURIER
     _name.object_id               ATOM_SITE_DISPLACE_FOURIER_PARAM
-
-    loop_
-      _category_key.name
-         '_atom_site_displace_Fourier_param.id'
-         '_atom_site_displace_Fourier_param.structure_id'
-
+    _category_key.name            '_atom_site_displace_Fourier_param.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -2647,31 +2481,12 @@ save_atom_site_displace_fourier_param.sin_su
 
 save_
 
-save_atom_site_displace_fourier_param.structure_id
-
-    _definition.id
-        '_atom_site_displace_Fourier_param.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_displace_Fourier_param
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_DISPLACE_LEGENDRE
 
     _definition.id                ATOM_SITE_DISPLACE_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2025-06-04
     _description.text
 ;
       The set of harmonic functions used in the Fourier series
@@ -2732,12 +2547,7 @@ save_ATOM_SITE_DISPLACE_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_LEGENDRE
-
-    loop_
-      _category_key.name
-         '_atom_site_displace_Legendre.id'
-         '_atom_site_displace_Legendre.structure_id'
-
+    _category_key.name            '_atom_site_displace_Legendre.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -2818,8 +2628,7 @@ save_atom_site_displace_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_displace_Legendre.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the Legendre components of its displacive modulation are listed.
       This code must match the _atom_site.label of the associated
       coordinate list and conform to the rules described in _atom_site.label.
@@ -2980,30 +2789,12 @@ save_atom_site_displace_legendre.order
 
 save_
 
-save_atom_site_displace_legendre.structure_id
-
-    _definition.id                '_atom_site_displace_Legendre.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_displace_Legendre
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_DISPLACE_ORTHO
 
     _definition.id                ATOM_SITE_DISPLACE_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_ORTHO category record
@@ -3031,12 +2822,7 @@ save_ATOM_SITE_DISPLACE_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_ORTHO
-
-    loop_
-      _category_key.name
-         '_atom_site_displace_ortho.id'
-         '_atom_site_displace_ortho.structure_id'
-
+    _category_key.name            '_atom_site_displace_ortho.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -3154,8 +2940,7 @@ save_atom_site_displace_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_displace_ortho.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the ortho components of its displacive modulation are listed.
       This code must match the _atom_site.label of the associated
       coordinate list andconform to the rules described in _atom_site.label.
@@ -3315,24 +3100,6 @@ save_atom_site_displace_ortho.matrix_seq_id
 
 save_
 
-save_atom_site_displace_ortho.structure_id
-
-    _definition.id                '_atom_site_displace_ortho.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_displace_ortho
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_DISPLACE_SAWTOOTH
 
     _definition.id                ATOM_SITE_DISPLACE_SAWTOOTH
@@ -3393,11 +3160,7 @@ save_ATOM_SITE_DISPLACE_SAWTOOTH
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_SAWTOOTH
-
-    loop_
-      _category_key.name
-         '_atom_site_displace_sawtooth.atom_site_label'
-         '_atom_site_displace_sawtooth.structure_id'
+    _category_key.name            '_atom_site_displace_sawtooth.atom_site_label'
 
     loop_
       _description_example.case
@@ -3483,8 +3246,7 @@ save_atom_site_displace_sawtooth.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_displace_sawtooth.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the sawtooth function that describes its displacive modulation is
       being defined. This code must match the _atom_site.label of the
       associated coordinate list and conform to the rules described in
@@ -3728,24 +3490,6 @@ save_atom_site_displace_sawtooth.matrix_seq_id
 
 save_
 
-save_atom_site_displace_sawtooth.structure_id
-
-    _definition.id                '_atom_site_displace_sawtooth.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_displace_sawtooth
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_displace_sawtooth.w
 
     _definition.id                '_atom_site_displace_sawtooth.w'
@@ -3787,7 +3531,7 @@ save_ATOM_SITE_DISPLACE_XHARM
     _definition.id                ATOM_SITE_DISPLACE_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       The set of harmonic functions used in the Fourier series
@@ -3846,12 +3590,7 @@ save_ATOM_SITE_DISPLACE_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_XHARM
-
-    loop_
-      _category_key.name
-         '_atom_site_displace_xharm.id'
-         '_atom_site_displace_xharm.structure_id'
-
+    _category_key.name            '_atom_site_displace_xharm.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -3937,8 +3676,7 @@ save_atom_site_displace_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-       The code, along with _atom_site_displace_xharm.structure_id, that
-       identifies an atom or rigid group in a loop in which the
+       The code that identifies an atom or rigid group in a loop in which the
        x-harmonics components of its displacive modulation are listed. In
        the case of a rigid group, this list would only include the
        translational part of its displacive modulation. The rotational part
@@ -4106,24 +3844,6 @@ save_atom_site_displace_xharm.order
 
 save_
 
-save_atom_site_displace_xharm.structure_id
-
-    _definition.id                '_atom_site_displace_xharm.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_displace_xharm
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_DISPLACE_ZIGZAG
 
     _definition.id                ATOM_SITE_DISPLACE_ZIGZAG
@@ -4165,12 +3885,7 @@ save_ATOM_SITE_DISPLACE_ZIGZAG
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_DISPLACE_ZIGZAG
-
-    loop_
-      _category_key.name
-         '_atom_site_displace_zigzag.atom_site_label'
-         '_atom_site_displace_zigzag.structure_id'
-
+    _category_key.name            '_atom_site_displace_zigzag.atom_site_label'
     _description_example.case
 ;
     #\#CIF_2.0
@@ -4225,8 +3940,7 @@ save_atom_site_displace_zigzag.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_displace_zigzag.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the zigzag function that describes its displacive modulation is
       being defined. This code must match the _atom_site.label of the
       associated coordinate list and conform to the rules described in
@@ -4327,24 +4041,6 @@ save_atom_site_displace_zigzag.matrix_seq_id
 
     _import.get
         [{'file':templ_attr.cif  'save':transf_matrix_id}]
-
-save_
-
-save_atom_site_displace_zigzag.structure_id
-
-    _definition.id                '_atom_site_displace_zigzag.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_displace_zigzag
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -5104,7 +4800,7 @@ save_ATOM_SITE_OCC_CRENEL
     _definition.id                ATOM_SITE_OCC_CRENEL
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2025-06-04
     _description.text
 ;
       Data items in the ATOM_SITE_OCC_CRENEL category record
@@ -5123,12 +4819,7 @@ save_ATOM_SITE_OCC_CRENEL
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_CRENEL
-
-    loop_
-      _category_key.name
-         '_atom_site_occ_crenel.atom_site_label'
-         '_atom_site_occ_crenel.structure_id'
-
+    _category_key.name            '_atom_site_occ_crenel.atom_site_label'
     _description_example.case
 ;
     #\#CIF_2.0
@@ -5191,8 +4882,7 @@ save_atom_site_occ_crenel.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_occ_crenel.structure_id, that
-      identifies an atom or rigid group in a loop in
+      The code that identifies an atom or rigid group in a loop in
       which the parameters of the crenel function that describes its
       occupational modulation are listed. This code must match
       the _atom_site.label of the associated coordinate list and
@@ -5283,24 +4973,6 @@ save_atom_site_occ_crenel.ortho_eps
 
 save_
 
-save_atom_site_occ_crenel.structure_id
-
-    _definition.id                '_atom_site_occ_crenel.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_occ_crenel
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_occ_crenel.w
 
     _definition.id                '_atom_site_occ_crenel.w'
@@ -5347,7 +5019,7 @@ save_ATOM_SITE_OCC_FOURIER
     _definition.id                ATOM_SITE_OCC_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_OCC_FOURIER category record details
@@ -5358,12 +5030,7 @@ save_ATOM_SITE_OCC_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_FOURIER
-
-    loop_
-      _category_key.name
-         '_atom_site_occ_Fourier.id'
-         '_atom_site_occ_Fourier.structure_id'
-
+    _category_key.name            '_atom_site_occ_Fourier.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -5447,8 +5114,7 @@ save_atom_site_occ_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_occ_fourier.structure_id, that
-      identifies an atom in a loop in which the Fourier
+      The code that identifies an atom in a loop in which the Fourier
       components of its occupational modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -5483,24 +5149,6 @@ save_atom_site_occ_fourier.id
 
 save_
 
-save_atom_site_occ_fourier.structure_id
-
-    _definition.id                '_atom_site_occ_Fourier.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_occ_Fourier
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_occ_fourier.wave_vector_seq_id
 
     _definition.id                '_atom_site_occ_Fourier.wave_vector_seq_id'
@@ -5530,7 +5178,7 @@ save_ATOM_SITE_OCC_FOURIER_PARAM
     _definition.id                ATOM_SITE_OCC_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-07-31
     _description.text
 ;
       Data items in the ATOM_SITE_OCC_FOURIER_PARAM category record
@@ -5559,12 +5207,7 @@ save_ATOM_SITE_OCC_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_OCC_FOURIER
     _name.object_id               ATOM_SITE_OCC_FOURIER_PARAM
-
-    loop_
-      _category_key.name
-         '_atom_site_occ_Fourier_param.id'
-         '_atom_site_occ_Fourier_param.structure_id'
-
+    _category_key.name            '_atom_site_occ_Fourier_param.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -5856,30 +5499,12 @@ save_atom_site_occ_fourier_param.sin_su
 
 save_
 
-save_atom_site_occ_fourier_param.structure_id
-
-    _definition.id                '_atom_site_occ_Fourier_param.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_occ_Fourier_param
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_OCC_LEGENDRE
 
     _definition.id                ATOM_SITE_OCC_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_OCC_LEGENDRE category record
@@ -5890,11 +5515,7 @@ save_ATOM_SITE_OCC_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_LEGENDRE
-
-    loop_
-      _category_key.name
-         '_atom_site_occ_Legendre.id'
-         '_atom_site_occ_Legendre.structure_id'
+    _category_key.name            '_atom_site_occ_Legendre.id'
 
 save_
 
@@ -5905,8 +5526,7 @@ save_atom_site_occ_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_occ_legendre.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the Legendre components of its occupational modulation are listed.
       This code must match the _atom_site.label of the associated coordinate
       list and conform to the rules described in _atom_site.label.
@@ -5996,30 +5616,12 @@ save_atom_site_occ_legendre.order
 
 save_
 
-save_atom_site_occ_legendre.structure_id
-
-    _definition.id                '_atom_site_occ_Legendre.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_occ_Legendre
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_OCC_ORTHO
 
     _definition.id                ATOM_SITE_OCC_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
 
@@ -6039,11 +5641,7 @@ save_ATOM_SITE_OCC_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_ORTHO
-
-    loop_
-      _category_key.name
-         '_atom_site_occ_ortho.id'
-         '_atom_site_occ_ortho.structure_id'
+    _category_key.name            '_atom_site_occ_ortho.id'
 
 save_
 
@@ -6055,8 +5653,7 @@ save_atom_site_occ_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_occ_ortho.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the ortho components of its occupational modulation are listed.
       This code must match the _atom_site.label of the associated coordinate
       list and conform to the rules described in _atom_site.label.
@@ -6148,24 +5745,6 @@ save_atom_site_occ_ortho.id
 
 save_
 
-save_atom_site_occ_ortho.structure_id
-
-    _definition.id                '_atom_site_occ_ortho.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_occ_ortho
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_OCC_XHARM
 
     _definition.id                ATOM_SITE_OCC_XHARM
@@ -6182,11 +5761,7 @@ save_ATOM_SITE_OCC_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_OCC_XHARM
-
-    loop_
-      _category_key.name
-         '_atom_site_occ_xharm.id'
-         '_atom_site_occ_xharm.structure_id'
+    _category_key.name            '_atom_site_occ_xharm.id'
 
 save_
 
@@ -6197,8 +5772,7 @@ save_atom_site_occ_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_occ_xharm.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the x-harmonic components of its occupational modulation are listed.
       This code must match the _atom_site.label of the associated coordinate
       list and conform to the rules described in _atom_site.label.
@@ -6288,30 +5862,12 @@ save_atom_site_occ_xharm.order
 
 save_
 
-save_atom_site_occ_xharm.structure_id
-
-    _definition.id                '_atom_site_occ_xharm.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_occ_xharm
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_PHASON
 
     _definition.id                ATOM_SITE_PHASON
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_PHASON category record details
@@ -6322,11 +5878,7 @@ save_ATOM_SITE_PHASON
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_PHASON
-
-    loop_
-      _category_key.name
-         '_atom_site_phason.atom_site_label'
-         '_atom_site_phason.structure_id'
+    _category_key.name            '_atom_site_phason.atom_site_label'
 
 save_
 
@@ -6337,8 +5889,7 @@ save_atom_site_phason.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_phason.structure_id, that
-      identifies an atom or rigid group in a loop in
+      The code that identifies an atom or rigid group in a loop in
       which the phason coefficients are listed. Although this kind of
       correction is intended to be overall, some refinement programs
       (for example, JANA) allow an independent phason correction
@@ -6429,30 +5980,12 @@ save_atom_site_phason.formula
 
 save_
 
-save_atom_site_phason.structure_id
-
-    _definition.id                '_atom_site_phason.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_phason
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_ROT_FOURIER
 
     _definition.id                ATOM_SITE_ROT_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2025-06-04
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_FOURIER category record details
@@ -6466,12 +5999,7 @@ save_ATOM_SITE_ROT_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_FOURIER
-
-    loop_
-      _category_key.name
-         '_atom_site_rot_Fourier.id'
-         '_atom_site_rot_Fourier.structure_id'
-
+    _category_key.name            '_atom_site_rot_Fourier.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -6656,8 +6184,7 @@ save_atom_site_rot_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_rot_fourier.structure_id, that
-      identifies a rigid group in a loop in which the Fourier
+      The code that identifies a rigid group in a loop in which the Fourier
       components of the rotational part of its displacive modulation
       are listed. The translational part (if any) would appear in a
       separate list (see _atom_site_displace_Fourier.atom_site_label).
@@ -6761,24 +6288,6 @@ save_atom_site_rot_fourier.matrix_seq_id
 
 save_
 
-save_atom_site_rot_fourier.structure_id
-
-    _definition.id                '_atom_site_rot_Fourier.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_rot_Fourier
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_rot_fourier.wave_vector_seq_id
 
     _definition.id                '_atom_site_rot_Fourier.wave_vector_seq_id'
@@ -6808,7 +6317,7 @@ save_ATOM_SITE_ROT_FOURIER_PARAM
     _definition.id                ATOM_SITE_ROT_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2025-06-04
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_FOURIER_PARAM category record
@@ -6849,12 +6358,7 @@ save_ATOM_SITE_ROT_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_ROT_FOURIER
     _name.object_id               ATOM_SITE_ROT_FOURIER_PARAM
-
-    loop_
-      _category_key.name
-         '_atom_site_rot_Fourier_param.id'
-         '_atom_site_rot_Fourier_param.structure_id'
-
+    _category_key.name            '_atom_site_rot_Fourier_param.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -7287,30 +6791,12 @@ save_atom_site_rot_fourier_param.sin_su
 
 save_
 
-save_atom_site_rot_fourier_param.structure_id
-
-    _definition.id                '_atom_site_rot_Fourier_param.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_rot_Fourier_param
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_ROT_LEGENDRE
 
     _definition.id                ATOM_SITE_ROT_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_LEGENDRE category record
@@ -7323,11 +6809,7 @@ save_ATOM_SITE_ROT_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_LEGENDRE
-
-    loop_
-      _category_key.name
-         '_atom_site_rot_Legendre.id'
-         '_atom_site_rot_Legendre.structure_id'
+    _category_key.name            '_atom_site_rot_Legendre.id'
 
 save_
 
@@ -7337,8 +6819,7 @@ save_atom_site_rot_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_rot_legendre.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the Legendre components of its displacive modulation are listed.
       In the case of a rigid group, this list would only include the
       rotational part of its displacive modulation. The translational
@@ -7498,30 +6979,12 @@ save_atom_site_rot_legendre.order
 
 save_
 
-save_atom_site_rot_legendre.structure_id
-
-    _definition.id                '_atom_site_rot_Legendre.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_rot_Legendre
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_ROT_ORTHO
 
     _definition.id                ATOM_SITE_ROT_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_ORTHO category record
@@ -7542,11 +7005,7 @@ save_ATOM_SITE_ROT_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_ORTHO
-
-    loop_
-      _category_key.name
-         '_atom_site_rot_ortho.id'
-         '_atom_site_rot_ortho.structure_id'
+    _category_key.name            '_atom_site_rot_ortho.id'
 
 save_
 
@@ -7556,8 +7015,7 @@ save_atom_site_rot_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_rot_ortho.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the ortho components of its displacive modulation are listed.
       In the case of a rigid group, this list would only include the
       rotational part of its displacive modulation. The translational
@@ -7720,30 +7178,12 @@ save_atom_site_rot_ortho.matrix_seq_id
 
 save_
 
-save_atom_site_rot_ortho.structure_id
-
-    _definition.id                '_atom_site_rot_ortho.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_rot_ortho
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_ROT_SAWTOOTH
 
     _definition.id                ATOM_SITE_ROT_SAWTOOTH
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2025-06-04
     _description.text
 ;
       Data items in the ATOM_SITE_DISPLACE_SAWTOOTH category record
@@ -7771,11 +7211,7 @@ save_ATOM_SITE_ROT_SAWTOOTH
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_SAWTOOTH
-
-    loop_
-      _category_key.name
-         '_atom_site_rot_sawtooth.atom_site_label'
-         '_atom_site_rot_sawtooth.structure_id'
+    _category_key.name            '_atom_site_rot_sawtooth.atom_site_label'
 
 save_
 
@@ -7786,8 +7222,7 @@ save_atom_site_rot_sawtooth.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_rot_sawtooth.structure_id, that
-      identifies a rigid group in a loop in which a sawtooth
+      The code that identifies a rigid group in a loop in which a sawtooth
       function that describes the rotational part of its displacive
       modulation is being defined. This code must match the _atom_site.label
       of the associated coordinate list and conform to the rules described
@@ -8031,24 +7466,6 @@ save_atom_site_rot_sawtooth.matrix_seq_id
 
 save_
 
-save_atom_site_rot_sawtooth.structure_id
-
-    _definition.id                '_atom_site_rot_sawtooth.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_rot_sawtooth
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_rot_sawtooth.w
 
     _definition.id                '_atom_site_rot_sawtooth.w'
@@ -8090,7 +7507,7 @@ save_ATOM_SITE_ROT_XHARM
     _definition.id                ATOM_SITE_ROT_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_XHARM category record
@@ -8103,11 +7520,7 @@ save_ATOM_SITE_ROT_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_XHARM
-
-    loop_
-      _category_key.name
-         '_atom_site_rot_xharm.id'
-         '_atom_site_rot_xharm.structure_id'
+    _category_key.name            '_atom_site_rot_xharm.id'
 
 save_
 
@@ -8117,8 +7530,7 @@ save_atom_site_rot_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_rot_xharm.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       the x-harmonics components of its displacive modulation are listed.
       In the case of a rigid group, this list would only include the
       rotational part of its displacive modulation. The translational
@@ -8278,30 +7690,12 @@ save_atom_site_rot_xharm.order
 
 save_
 
-save_atom_site_rot_xharm.structure_id
-
-    _definition.id                '_atom_site_rot_xharm.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_rot_xharm
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_ROT_ZIGZAG
 
     _definition.id                ATOM_SITE_ROT_ZIGZAG
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2025-06-04
     _description.text
 ;
       Data items in the ATOM_SITE_ROT_ZIGZAG category record
@@ -8331,11 +7725,7 @@ save_ATOM_SITE_ROT_ZIGZAG
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_ROT_ZIGZAG
-
-    loop_
-      _category_key.name
-         '_atom_site_rot_zigzag.atom_site_label'
-         '_atom_site_rot_zigzag.structure_id'
+    _category_key.name            '_atom_site_rot_zigzag.atom_site_label'
 
 save_
 
@@ -8345,8 +7735,7 @@ save_atom_site_rot_zigzag.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_rot_zigzag.structure_id, that
-      identifies an atom or rigid group in a loop in which
+      The code that identifies an atom or rigid group in a loop in which
       a zigzag function that describes the rotational part of its displacive
       modulation is being defined. This code must match the _atom_site.label
       of the associated coordinate list and conform to the rules described
@@ -8450,24 +7839,6 @@ save_atom_site_rot_zigzag.matrix_seq_id
 
 save_
 
-save_atom_site_rot_zigzag.structure_id
-
-    _definition.id                '_atom_site_rot_zigzag.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_rot_zigzag
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_rot_zigzag.w
 
     _definition.id                '_atom_site_rot_zigzag.w'
@@ -8508,7 +7879,7 @@ save_ATOM_SITE_U_FOURIER
     _definition.id                ATOM_SITE_U_FOURIER
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_U_FOURIER category record details
@@ -8519,12 +7890,7 @@ save_ATOM_SITE_U_FOURIER
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_FOURIER
-
-    loop_
-      _category_key.name
-         '_atom_site_U_Fourier.id'
-         '_atom_site_U_Fourier.structure_id'
-
+    _category_key.name            '_atom_site_U_Fourier.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -8634,8 +8000,7 @@ save_atom_site_u_fourier.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_u_fourier.structure_id, that
-      identifies an atom in a loop in which the Fourier
+      The code that identifies an atom in a loop in which the Fourier
       components of its harmonic ADP modulation are listed.  This code
       must match the _atom_site.label of the associated coordinate list
       and conform to the rules described in _atom_site.label.
@@ -8666,24 +8031,6 @@ save_atom_site_u_fourier.id
     _type.source                  Related
     _type.container               Single
     _type.contents                Code
-
-save_
-
-save_atom_site_u_fourier.structure_id
-
-    _definition.id                '_atom_site_U_Fourier.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_U_Fourier
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -8747,7 +8094,7 @@ save_ATOM_SITE_U_FOURIER_PARAM
     _definition.id                ATOM_SITE_U_FOURIER_PARAM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-07-31
     _description.text
 ;
       Data items in the ATOM_SITE_U_FOURIER_PARAM category record details
@@ -8779,12 +8126,7 @@ save_ATOM_SITE_U_FOURIER_PARAM
 ;
     _name.category_id             ATOM_SITE_U_FOURIER
     _name.object_id               ATOM_SITE_U_FOURIER_PARAM
-
-    loop_
-      _category_key.name
-         '_atom_site_U_Fourier_param.id'
-         '_atom_site_U_Fourier_param.structure_id'
-
+    _category_key.name            '_atom_site_U_Fourier_param.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -9118,30 +8460,12 @@ save_atom_site_u_fourier_param.sin_su
 
 save_
 
-save_atom_site_u_fourier_param.structure_id
-
-    _definition.id                '_atom_site_U_Fourier_param.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_U_Fourier_param
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITE_U_LEGENDRE
 
     _definition.id                ATOM_SITE_U_LEGENDRE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_U_LEGENDRE category record
@@ -9152,12 +8476,7 @@ save_ATOM_SITE_U_LEGENDRE
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_LEGENDRE
-
-    loop_
-      _category_key.name
-         '_atom_site_U_Legendre.id'
-         '_atom_site_U_Legendre.structure_id'
-
+    _category_key.name            '_atom_site_u_Legendre.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -9254,8 +8573,7 @@ save_atom_site_u_legendre.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_u_legendre.structure_id, that
-      identifies an atom in a loop in which the Legendre
+      The code that identifies an atom in a loop in which the Legendre
       components of its harmonic ADP modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -9346,24 +8664,6 @@ save_atom_site_u_legendre.order
 
 save_
 
-save_atom_site_u_legendre.structure_id
-
-    _definition.id                '_atom_site_U_Legendre.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_U_Legendre
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_u_legendre.tens_elem
 
     _definition.id                '_atom_site_U_Legendre.tens_elem'
@@ -9400,7 +8700,7 @@ save_ATOM_SITE_U_ORTHO
     _definition.id                ATOM_SITE_U_ORTHO
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_U_ORTHO category record
@@ -9419,11 +8719,7 @@ save_ATOM_SITE_U_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_ORTHO
-
-    loop_
-      _category_key.name
-         '_atom_site_U_ortho.id'
-         '_atom_site_U_ortho.structure_id'
+    _category_key.name            '_atom_site_U_ortho.id'
 
 save_
 
@@ -9435,8 +8731,7 @@ save_atom_site_u_ortho.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_u_ortho.structure_id, that
-      identifies an atom in a loop in which the ortho
+      The code that identifies an atom in a loop in which the ortho
       components of its harmonic ADP modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -9528,24 +8823,6 @@ save_atom_site_u_ortho.id
 
 save_
 
-save_atom_site_u_ortho.structure_id
-
-    _definition.id                '_atom_site_U_ortho.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_U_ortho
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_u_ortho.tens_elem
 
     _definition.id                '_atom_site_U_ortho.tens_elem'
@@ -9583,7 +8860,7 @@ save_ATOM_SITE_U_XHARM
     _definition.id                ATOM_SITE_U_XHARM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-03
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITE_U_XHARM category record details about
@@ -9593,12 +8870,7 @@ save_ATOM_SITE_U_XHARM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITE_U_XHARM
-
-    loop_
-      _category_key.name
-         '_atom_site_U_xharm.id'
-         '_atom_site_U_xharm.structure_id'
-
+    _category_key.name            '_atom_site_U_xharm.id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -9705,8 +8977,7 @@ save_atom_site_u_xharm.atom_site_label
     _definition.update            2025-10-20
     _description.text
 ;
-      The code, along with _atom_site_u_xharm.structure_id, that
-      identifies an atom in a loop in which the x-harmonic
+      The code that identifies an atom in a loop in which the x-harmonic
       components of its harmonic ADP modulation are listed. This code must
       match the _atom_site.label of the associated coordinate list and
       conform to the rules described in _atom_site.label.
@@ -9796,24 +9067,6 @@ save_atom_site_u_xharm.order
 
 save_
 
-save_atom_site_u_xharm.structure_id
-
-    _definition.id                '_atom_site_U_xharm.structure_id'
-    _definition.update            2026-06-03
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
-    _name.category_id             atom_site_U_xharm
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_atom_site_u_xharm.tens_elem
 
     _definition.id                '_atom_site_U_xharm.tens_elem'
@@ -9849,7 +9102,7 @@ save_ATOM_SITES_AXES
     _definition.id                ATOM_SITES_AXES
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-15
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the ATOM_SITES_AXES category record
@@ -9860,12 +9113,7 @@ save_ATOM_SITES_AXES
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_AXES
-
-    loop_
-      _category_key.name
-         '_atom_sites_axes.matrix_seq_id'
-         '_atom_sites_axes.structure_id'
-
+    _category_key.name            '_atom_sites_axes.matrix_seq_id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -9946,25 +9194,6 @@ save_atom_sites_axes.matrix_seq_id
     _type.contents                Integer
     _enumeration.range            0:
     _units.code                   none
-
-save_
-
-save_atom_sites_axes.structure_id
-
-    _definition.id                '_atom_sites_axes.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with the
-    atom sites.
-;
-    _name.category_id             atom_sites_axes
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -10055,7 +9284,7 @@ save_ATOM_SITES_MODULATION
     _definition.id                ATOM_SITES_MODULATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2026-06-15
+    _definition.update            2025-06-04
     _description.text
 ;
       Data items in the ATOM_SITES_MODULATION category record details
@@ -10063,7 +9292,6 @@ save_ATOM_SITES_MODULATION
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_MODULATION
-    _category_key.name            '_atom_sites_modulation.structure_id'
     _description_example.case
 ;
         #\#CIF_2.0
@@ -10433,25 +9661,6 @@ save_atom_sites_modulation.global_phase_t_9
 
 save_
 
-save_atom_sites_modulation.structure_id
-
-    _definition.id                '_atom_sites_modulation.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with the
-    atom sites.
-;
-    _name.category_id             atom_sites_modulation
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_ATOM_SITES_ORTHO
 
     _definition.id                ATOM_SITES_ORTHO
@@ -10488,12 +9697,7 @@ save_ATOM_SITES_ORTHO
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               ATOM_SITES_ORTHO
-
-    loop_
-      _category_key.name
-         '_atom_sites_ortho.func_id'
-         '_atom_sites_ortho.structure_id'
-
+    _category_key.name            '_atom_sites_ortho.func_id'
     _description_example.case
 ;
     #\#CIF_2.0
@@ -10619,25 +9823,6 @@ save_atom_sites_ortho.func_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Code
-
-save_
-
-save_atom_sites_ortho.structure_id
-
-    _definition.id                '_atom_sites_ortho.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with the
-    atom sites.
-;
-    _name.category_id             atom_sites_ortho
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -16131,7 +15316,7 @@ save_GEOM_ANGLE
     _definition.id                GEOM_ANGLE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-15
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the GEOM_ANGLE category record
@@ -16154,7 +15339,6 @@ save_GEOM_ANGLE
          '_geom_angle.atom_site_label_1'
          '_geom_angle.atom_site_label_2'
          '_geom_angle.atom_site_label_3'
-         '_geom_angle.model_id'
          '_geom_angle.site_ssg_symmetry_1'
          '_geom_angle.site_ssg_symmetry_2'
          '_geom_angle.site_ssg_symmetry_3'
@@ -16469,7 +15653,7 @@ save_GEOM_BOND
     _definition.id                GEOM_BOND
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-15
+    _definition.update            2024-08-09
     _description.text
 ;
       Data items in the GEOM_BOND category record
@@ -16487,7 +15671,6 @@ save_GEOM_BOND
       _category_key.name
          '_geom_bond.atom_site_label_1'
          '_geom_bond.atom_site_label_2'
-         '_geom_bond.model_id'
          '_geom_bond.site_ssg_symmetry_1'
          '_geom_bond.site_ssg_symmetry_2'
 
@@ -16675,7 +15858,7 @@ save_GEOM_CONTACT
     _definition.id                GEOM_CONTACT
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-15
+    _definition.update            2024-08-09
     _description.text
 ;
       The CATEGORY of data items used to specify the interatomic
@@ -16691,7 +15874,6 @@ save_GEOM_CONTACT
       _category_key.name
          '_geom_contact.atom_site_label_1'
          '_geom_contact.atom_site_label_2'
-         '_geom_contact.model_id'
          '_geom_contact.site_ssg_symmetry_1'
          '_geom_contact.site_ssg_symmetry_2'
 
@@ -16840,7 +16022,7 @@ save_GEOM_HBOND
     _definition.id                GEOM_HBOND
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-15
+    _definition.update            2024-08-09
     _description.text
 ;
      The CATEGORY of data items used to specify the hydrogen bond
@@ -16858,7 +16040,6 @@ save_GEOM_HBOND
          '_geom_hbond.atom_site_label_D'
          '_geom_hbond.atom_site_label_H'
          '_geom_hbond.atom_site_label_A'
-         '_geom_hbond.model_id'
          '_geom_hbond.site_ssg_symmetry_D'
          '_geom_hbond.site_ssg_symmetry_H'
          '_geom_hbond.site_ssg_symmetry_A'
@@ -17377,7 +16558,7 @@ save_GEOM_TORSION
     _definition.id                GEOM_TORSION
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-15
+    _definition.update            2024-08-09
     _description.text
 ;
      The CATEGORY of data items used to specify the torsion angles in the
@@ -17396,7 +16577,6 @@ save_GEOM_TORSION
          '_geom_torsion.atom_site_label_2'
          '_geom_torsion.atom_site_label_3'
          '_geom_torsion.atom_site_label_4'
-         '_geom_torsion.model_id'
          '_geom_torsion.site_ssg_symmetry_1'
          '_geom_torsion.site_ssg_symmetry_2'
          '_geom_torsion.site_ssg_symmetry_3'
@@ -17863,7 +17043,7 @@ save_REFLN
     _definition.id                REFLN
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2026-06-05
+    _definition.update            2025-06-22
     _description.text
 ;
       Data items in the REFLN category record details about the
@@ -17878,11 +17058,7 @@ save_REFLN
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               REFLN
-
-    loop_
-      _category_key.name
-         '_refln.id'
-         '_refln.structure_id'
+    _category_key.name            '_refln.id'
 
 save_
 
@@ -18108,25 +17284,6 @@ save_refln.index_m_list
            _refln.index_m_list =                                              \
                 temp.index_m_list[0:_cell.modulation_dimension - 1]
 ;
-
-save_
-
-save_refln.structure_id
-
-    _definition.id                '_refln.structure_id'
-    _definition.update            2026-06-05
-    _description.text
-;
-    A code identifying the crystallographic structure associated with this
-    reflection.
-;
-    _name.category_id             refln
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -19644,59 +18801,11 @@ save_
         _diffrn_refln.id and _refln.id, respectively.
 
         2026-06-15
-        Add new key to REFLN: _refln.structure_id, linked to _structure.id.
-        Needed to match redefinition in MULTI_BLOCK_CORE.
-
-        2026-06-03
-        Added _structure.id keys to:
-        ATOM_SITE_ANHARMONIC_ADP
-        ATOM_SITE_DISPLACE_SAWTOOTH
-        ATOM_SITE_DISPLACE_ZIGZAG
-        ATOM_SITE_OCC_CRENEL
-        ATOM_SITE_PHASON
-        ATOM_SITE_ROT_SAWTOOTH
-        ATOM_SITE_ROT_ZIGZAG
-
-        ATOM_SITE_ANHARMONIC_ADP_FOURIER
-        ATOM_SITE_ANHARMONIC_ADP_FOURIER_PARAM
-        ATOM_SITE_ANHARMONIC_ADP_LEGENDRE
-        ATOM_SITE_ANHARMONIC_ADP_ORTHO
-        ATOM_SITE_ANHARMONIC_ADP_XHARM
-        ATOM_SITE_DISPLACE_FOURIER
-        ATOM_SITE_DISPLACE_FOURIER_PARAM
-        ATOM_SITE_DISPLACE_LEGENDRE
-        ATOM_SITE_DISPLACE_ORTHO
-        ATOM_SITE_DISPLACE_XHARM
-        ATOM_SITE_OCC_FOURIER
-        ATOM_SITE_OCC_FOURIER_PARAM
-        ATOM_SITE_OCC_LEGENDRE
-        ATOM_SITE_OCC_ORTHO
-        ATOM_SITE_OCC_XHARM
-        ATOM_SITE_ROT_FOURIER
-        ATOM_SITE_ROT_FOURIER_PARAM
-        ATOM_SITE_ROT_LEGENDRE
-        ATOM_SITE_ROT_ORTHO
-        ATOM_SITE_ROT_XHARM
-        ATOM_SITE_U_FOURIER
-        ATOM_SITE_U_FOURIER_PARAM
-        ATOM_SITE_U_LEGENDRE
-        ATOM_SITE_U_ORTHO
-        ATOM_SITE_U_XHARM
-
-        2026-06-15
-        2026-06-15
-        Added linked key *.structure_id data names to ATOM_SITES_AXES,
-        ATOM_SITES_MODULATION, and ATOM_SITES_ORTHO.
-
         Added key _superspace_group.id and linked key
         _superspace_group_symop.superspace_group_id
 
         Added linked non-key _structure.superspace_group_id
-
         2026-06-18
-
-        Added _geom_*.model_id as linked key data name to GEOM_ANGLE, BOND,
-        CONTACT, HBOND, and TORSION, mimicking CIF_MULTI.
 
         Explicitly deprecated the ATOM_SITES_DISPLACE_FOURIER category.
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13519,7 +13519,11 @@ save_CELL_WAVE_VECTOR
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               CELL_WAVE_VECTOR
-    _category_key.name            '_cell_wave_vector.seq_id'
+
+    loop_
+      _category_key.name
+         '_cell_wave_vector.seq_id'
+         '_cell_wave_vector.structure_id'
 
 save_
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13776,7 +13776,7 @@ save_CELL_WAVE_VECTORS
     _definition.id                CELL_WAVE_VECTORS
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2024-08-09
+    _definition.update            2026-06-30
     _description.text
 ;
       Data items in the CELL_WAVE_VECTORS category record overall details
@@ -13788,6 +13788,25 @@ save_CELL_WAVE_VECTORS
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               CELL_WAVE_VECTORS
+    _category_key.name            '_cell_wave_vectors.id'
+
+save_
+
+save_cell_wave_vectors.id
+
+    _definition.id                '_cell_wave_vectors.id'
+    _definition.update            2026-06-30
+    _description.text
+;
+    Unique identifier for the overall details under which cell wave
+    vectors were measured.
+;
+    _name.category_id             cell_wave_vectors
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -15315,7 +15315,7 @@ save_GEOM_ANGLE
     _definition.id                GEOM_ANGLE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the GEOM_ANGLE category record
@@ -15341,6 +15341,7 @@ save_GEOM_ANGLE
          '_geom_angle.atom_site_label_1'
          '_geom_angle.atom_site_label_2'
          '_geom_angle.atom_site_label_3'
+         '_geom_angle.model_id'
          '_geom_angle.site_ssg_symmetry_1'
          '_geom_angle.site_ssg_symmetry_2'
          '_geom_angle.site_ssg_symmetry_3'
@@ -15655,7 +15656,7 @@ save_GEOM_BOND
     _definition.id                GEOM_BOND
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
       Data items in the GEOM_BOND category record
@@ -15676,6 +15677,7 @@ save_GEOM_BOND
       _category_key.name
          '_geom_bond.atom_site_label_1'
          '_geom_bond.atom_site_label_2'
+         '_geom_bond.model_id'
          '_geom_bond.site_ssg_symmetry_1'
          '_geom_bond.site_ssg_symmetry_2'
 
@@ -15863,7 +15865,7 @@ save_GEOM_CONTACT
     _definition.id                GEOM_CONTACT
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
       The CATEGORY of data items used to specify the interatomic
@@ -15882,6 +15884,7 @@ save_GEOM_CONTACT
       _category_key.name
          '_geom_contact.atom_site_label_1'
          '_geom_contact.atom_site_label_2'
+         '_geom_contact.model_id'
          '_geom_contact.site_ssg_symmetry_1'
          '_geom_contact.site_ssg_symmetry_2'
 
@@ -16030,7 +16033,7 @@ save_GEOM_HBOND
     _definition.id                GEOM_HBOND
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
      The CATEGORY of data items used to specify the hydrogen bond
@@ -16051,6 +16054,7 @@ save_GEOM_HBOND
          '_geom_hbond.atom_site_label_D'
          '_geom_hbond.atom_site_label_H'
          '_geom_hbond.atom_site_label_A'
+         '_geom_hbond.model_id'
          '_geom_hbond.site_ssg_symmetry_D'
          '_geom_hbond.site_ssg_symmetry_H'
          '_geom_hbond.site_ssg_symmetry_A'
@@ -16569,7 +16573,7 @@ save_GEOM_TORSION
     _definition.id                GEOM_TORSION
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-06-15
     _description.text
 ;
      The CATEGORY of data items used to specify the torsion angles in the
@@ -16591,6 +16595,7 @@ save_GEOM_TORSION
          '_geom_torsion.atom_site_label_2'
          '_geom_torsion.atom_site_label_3'
          '_geom_torsion.atom_site_label_4'
+         '_geom_torsion.model_id'
          '_geom_torsion.site_ssg_symmetry_1'
          '_geom_torsion.site_ssg_symmetry_2'
          '_geom_torsion.site_ssg_symmetry_3'
@@ -18819,7 +18824,11 @@ save_
         _superspace_group_symop.superspace_group_id
 
         Added linked non-key _structure.superspace_group_id
+
         2026-06-18
+
+        Added _geom_*.model_id as linked key data name to GEOM_ANGLE, BOND,
+        CONTACT, HBOND, and TORSION, mimicking CIF_MULTI.
 
         Explicitly deprecated the ATOM_SITES_DISPLACE_FOURIER category.
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13529,22 +13529,11 @@ save_
 save_cell_wave_vector.structure_id
 
     _definition.id                '_cell_wave_vector.structure_id'
-    _definition.update            2026-06-30
-    _description.text
-;
-    A code identifying the crystallographic structure associated with the
-    cell wave vector.
-
-    This data name may be omitted if only one _structure.id is present in
-    the same data block.
-;
     _name.category_id             cell_wave_vector
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 


### PR DESCRIPTION
From discussion in #54

`cell_wave_vector` (`Loop`) gains:
- `Set` key to `_structure.id`: so we know the structure to which the vectors belong
- linked, non-key dataname to `_cell_wave_vectors.id`: so we know the conditions under which the vectors were measured. I took inspiration from `pd_peak` and `pd_peak_overall`.

`cell_wave_vectors` (`Set`) gains:
- `_cell_wave_vectors.id` to uniquely identify the conditions