### PR TITLE
Change the enum range of _atom_sites_axes.matrix_seq_id to 1:

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -9180,7 +9180,7 @@ save_
 save_atom_sites_axes.matrix_seq_id
 
     _definition.id                '_atom_sites_axes.matrix_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-06-30
     _description.text
 ;
       A numeric code to identify each transformation matrix given
@@ -9192,7 +9192,7 @@ save_atom_sites_axes.matrix_seq_id
     _type.source                  Related
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            0:
+    _enumeration.range            1:
     _units.code                   none
 
 save_
@@ -18764,4 +18764,7 @@ save_
 
         Improved deprecation of _atom_sites_displace_Fourier.axes_description
         and _atom_sites_rot_Fourier.axes_description.
+
+        Changed the lower enumeration range of _atom_sites_axes.matrix_seq_id
+        from 0 to 1.
 ;


### PR DESCRIPTION
This PR resolves issue #14.

Note, that this specific change was discussed in the referenced issue, but was neither explicitly supported nor refused by the main dictionary authors. Usage of this data item in category examples does not use the 0-th value.

For this PR to pass the automated checks, a similar PR in the Attribute_templates repository will need to be merged as well.