### PR TITLE
Update `cell_subsystem(s)` keys

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13462,7 +13462,7 @@ save_
 
 save_cell_subsystem.structure_id
 
-    _definition.id                '_cell_subsystems.structure_id'
+    _definition.id                '_cell_subsystem.structure_id'
     _definition.update            2026-07-06
     _description.text
 ;

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13443,7 +13443,7 @@ save_
 
 save_cell_subsystem.subsystems_id
 
-    _definition.id                '_space_group_generator.subsystems_id'
+    _definition.id                '_cell_subsystem.subsystems_id'
     _definition.update            2026-07-06
     _description.text
 ;

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13441,25 +13441,6 @@ save_cell_subsystem.matrix_w_9_9
 
 save_
 
-save_cell_subsystem.subsystems_id
-
-    _definition.id                '_cell_subsystem.subsystems_id'
-    _definition.update            2026-07-06
-    _description.text
-;
-    A code which identifies the cell subsystems information applicable
-    to this subsystem.
-;
-    _name.category_id             cell_subsystem
-    _name.object_id               subsystems_id
-    _name.linked_item_id          '_cell_subsystems.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_cell_subsystem.structure_id
 
     _definition.id                '_cell_subsystem.structure_id'
@@ -13472,6 +13453,25 @@ save_cell_subsystem.structure_id
     _name.category_id             cell_subsystem
     _name.object_id               structure_id
     _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_cell_subsystem.subsystems_id
+
+    _definition.id                '_cell_subsystem.subsystems_id'
+    _definition.update            2026-07-06
+    _description.text
+;
+    A code which identifies the cell subsystems information applicable
+    to this subsystem.
+;
+    _name.category_id             cell_subsystem
+    _name.object_id               subsystems_id
+    _name.linked_item_id          '_cell_subsystems.id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -10330,6 +10330,7 @@ save_CELL_SUBSYSTEM
     #\#CIF_2.0
 
     # - - - - data truncated for brevity - - - -
+    _structure.id   Sr14/11CoO3
 
     _cell.modulation_dimension               1
 

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -10391,12 +10391,10 @@ save_cell_subsystem.code
 
     _definition.id                '_cell_subsystem.code'
     _alias.definition_id          '_cell_subsystem_code'
-    _definition.update            2014-06-27
+    _definition.update            2026-07-06
     _description.text
 ;
-      The code identifying uniquely a certain composite subsystem.
-      This code is used to identify the data blocks that contain
-      the structural information associated with the subsystem.
+      The code uniquely identifying a certain composite subsystem.
 ;
     _name.category_id             cell_subsystem
     _name.object_id               code

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13465,7 +13465,7 @@ save_CELL_SUBSYSTEMS
     _definition.id                CELL_SUBSYSTEMS
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2016-11-17
+    _definition.update            2026-07-06
     _description.text
 ;
       Data items in the CELL_SUBSYSTEMS category describe overall aspects
@@ -13473,6 +13473,25 @@ save_CELL_SUBSYSTEMS
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               CELL_SUBSYSTEMS
+    _category_key.name            '_cell_subsystems.id'
+
+save_
+
+save_cell_subsystems.id
+
+    _definition.id                '_cell_subsystems.id'
+    _definition.update            2026-07-06
+    _description.text
+;
+    Unique identifier for the overall aspects of the subsystems present
+    in a composite.
+;
+    _name.category_id             cell_subsystems
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -18817,4 +18836,5 @@ save_
         2026-07-06
 
         Added _cell_subsystem.structure_id as linked category key.
+        Added _cell_subsystems.id as unique category key
 ;

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -25,7 +25,7 @@ data_CIF_MS
     _dictionary.formalism         Modulated
     _dictionary.class             Instance
     _dictionary.version           3.2.5
-    _dictionary.date              2026-06-30
+    _dictionary.date              2026-07-06
     _dictionary.uri               http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance   4.2.0
     _dictionary.licensing_SPDX    CC-BY-4.0
@@ -10310,7 +10310,7 @@ save_CELL_SUBSYSTEM
     _definition.id                CELL_SUBSYSTEM
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2024-08-09
+    _definition.update            2026-07-06
     _description.text
 ;
       Data items in the CELL_SUBSYSTEM category record details about
@@ -10319,7 +10319,12 @@ save_CELL_SUBSYSTEM
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               CELL_SUBSYSTEM
-    _category_key.name            '_cell_subsystem.code'
+
+    loop_
+      _category_key.name
+         '_cell_subsystem.code'
+         '_cell_subsystem.structure_id'
+
     _description_example.case
 ;
     #\#CIF_2.0
@@ -13434,6 +13439,25 @@ save_cell_subsystem.matrix_w_9_9
 
      _cell_subsystem.matrix_W_9_9 = c.matrix_W[8,8]
 ;
+
+save_
+
+save_cell_subsystem.structure_id
+
+    _definition.id                '_cell_subsystems.structure_id'
+    _definition.update            2026-07-06
+    _description.text
+;
+    A code identifying the crystallographic structure associated with this
+    subsystem description.
+;
+    _name.category_id             cell_subsystem
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -18682,7 +18706,7 @@ save_
         2024-12-12
         Technical fixes (JRH)
 ;
-         3.2.5                    2026-06-30
+         3.2.5                    2026-07-06
 ;
         _SPECIAL_FUNC categories, replaced by:
         _DISPLACE_SAWTOOTH
@@ -18790,4 +18814,8 @@ save_
 
         Changed the lower enumeration range of _atom_sites_axes.matrix_seq_id
         from 0 to 1.
+
+        2026-07-06
+
+        Added _cell_subsystem.structure_id as linked category key.
 ;

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -10316,6 +10316,9 @@ save_CELL_SUBSYSTEM
       Data items in the CELL_SUBSYSTEM category record details about
       the crystallographic cell parameters of each subsystem present in
       a composite.
+
+      _cell_subsystem.structure_id may be omitted if only one
+      _structure.id is present in the same data block.
 ;
     _name.category_id             CIF_MS_HEAD
     _name.object_id               CELL_SUBSYSTEM
@@ -13449,6 +13452,9 @@ save_cell_subsystem.structure_id
 ;
     A code identifying the crystallographic structure associated with this
     subsystem description.
+
+    This data name may be omitted if only one _structure.id is present
+    in the same data block.
 ;
     _name.category_id             cell_subsystem
     _name.object_id               structure_id

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13441,6 +13441,25 @@ save_cell_subsystem.matrix_w_9_9
 
 save_
 
+save_cell_subsystem.subsystems_id
+
+    _definition.id                '_space_group_generator.subsystems_id'
+    _definition.update            2026-07-06
+    _description.text
+;
+    A code which identifies the cell subsystems information applicable
+    to this subsystem.
+;
+    _name.category_id             cell_subsystem
+    _name.object_id               subsystems_id
+    _name.linked_item_id          '_cell_subsystems.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_cell_subsystem.structure_id
 
     _definition.id                '_cell_subsystems.structure_id'
@@ -18836,5 +18855,6 @@ save_
         2026-07-06
 
         Added _cell_subsystem.structure_id as linked category key.
+        Added _cell_subsystem.subsystems_id as linked non-key data name
         Added _cell_subsystems.id as unique category key
 ;

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -10415,7 +10415,7 @@ save_cell_subsystem.description
 ;
       Description of each subsystem defining a composite structurally.
       The number of definitions must match the number given in
-      _cell_subsystems_number.
+      _cell_subsystems.number.
 ;
     _name.category_id             cell_subsystem
     _name.object_id               description

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -13447,22 +13447,11 @@ save_
 save_cell_subsystem.structure_id
 
     _definition.id                '_cell_subsystem.structure_id'
-    _definition.update            2026-07-06
-    _description.text
-;
-    A code identifying the crystallographic structure associated with this
-    subsystem description.
-
-    This data name may be omitted if only one _structure.id is present
-    in the same data block.
-;
     _name.category_id             cell_subsystem
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 


### PR DESCRIPTION
As discussed in #54 
- Added _cell_subsystem.structure_id as linked composite key
- Added _cell_susbsystems.id as unique Set key
- Rephrased definition of _cell_subsystem.code to remove reference to data blocks
- Added _cell_subsystem.subsystems_id as linked non-key data name

This is my interpretation as to how subsystems work nowadays.
