### PR TITLE
Relax dimension requirements for some data items

### DIFF
--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -25,7 +25,7 @@ data_CIF_MS
     _dictionary.formalism         Modulated
     _dictionary.class             Instance
     _dictionary.version           3.2.5
-    _dictionary.date              2026-06-30
+    _dictionary.date              2026-07-28
     _dictionary.uri               http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance   4.2.0
     _dictionary.licensing_SPDX    CC-BY-4.0
@@ -4535,7 +4535,7 @@ save_
 save_atom_site_fourier_wave_vector.q_coeff
 
     _definition.id                '_atom_site_Fourier_wave_vector.q_coeff'
-    _definition.update            2025-10-28
+    _definition.update            2026-07-28
     _description.text
 ;
       The list of coefficients that express a given k as a linear combination
@@ -4550,20 +4550,13 @@ save_atom_site_fourier_wave_vector.q_coeff
     _type.purpose                 Number
     _type.source                  Derived
     _type.container               Matrix
+    _type.dimension               '[]'
     _type.contents                Integer
     _enumeration.default          [0]
     _units.code                   none
 
-    loop_
-      _method.purpose
-      _method.expression
-         Definition
-;
-         With c as cell
-
-          _type.dimension = '[c.modulation_dimension]'
-;
-         Evaluation
+    _method.purpose               Evaluation
+    _method.expression
 ;
          With m as atom_site_Fourier_wave_vector
 
@@ -4585,7 +4578,7 @@ save_atom_site_fourier_wave_vector.q_coeff_seq_id
 
     _definition.id
         '_atom_site_Fourier_wave_vector.q_coeff_seq_id'
-    _definition.update            2025-10-28
+    _definition.update            2026-07-28
     _description.text
 ;
       The list of numeric codes that identifies each independent wave vector
@@ -4601,20 +4594,13 @@ save_atom_site_fourier_wave_vector.q_coeff_seq_id
     _type.purpose                 Number
     _type.source                  Derived
     _type.container               Matrix
+    _type.dimension               '[]'
     _type.contents                Integer
     _enumeration.default          [1]
     _units.code                   none
 
-    loop_
-      _method.purpose
-      _method.expression
-         Definition
-;
-         With c as cell
-
-         _type.dimension = '[c.modulation_dimension]'
-;
-         Evaluation
+    _method.purpose               Evaluation
+    _method.expression
 ;
          With m as atom_site_Fourier_wave_vector
 
@@ -18710,7 +18696,7 @@ save_
         2024-12-12
         Technical fixes (JRH)
 ;
-         3.2.5                    2026-06-30
+         3.2.5                    2026-07-28
 ;
         _SPECIAL_FUNC categories, replaced by:
         _DISPLACE_SAWTOOTH
@@ -18820,4 +18806,10 @@ save_
 
         Changed the lower enumeration range of _atom_sites_axes.matrix_seq_id
         from 0 to 1.
+
+        2026-07-28
+
+        Relaxed dimension requirements for the
+        _atom_site_fourier_wave_vector.q_coeff_seq_id and
+        _atom_site_fourier_wave_vector.q_coeff data items.
 ;


### PR DESCRIPTION
Resolves issue #72.

Data items _atom_site_fourier_wave_vector.q_coeff_seq_id and _atom_site_fourier_wave_vector.q_coeff may have several values in the same data block that are lists of differing lengths as showcased by the category usage examples in the dictionary. Therefore, these items should be marked as having an unknown number of elements instead of requiring them to have the same number of elements as the modulation dimension.

Note, that there are several other data items that derive their dimension base on the `_cell.modulation_dimension` data item value (e.g. `_diffrn_reflns.limit_index_m_max_list`), however, I am not sure if these should also be relaxed.